### PR TITLE
Prompt snapshot fix line 557

### DIFF
--- a/src/commands/tool/prompt/snapshot.ts
+++ b/src/commands/tool/prompt/snapshot.ts
@@ -554,7 +554,7 @@ export async function execute(
       client,
       triggererName: interaction.user.displayName || interaction.user.globalName || interaction.user.username,
       // snapshot.triggererUserRow unlocks STM context (actualTriggeringUserId guard inside buildContext)
-      snapshot: { triggererUserRow: userData },
+      snapshot: { triggererUserRow: userData, tomoriState: effectivePersona },
       tomoriNickname: selectedPersona.tomori_nickname ?? process.env.DEFAULT_BOTNAME ?? "Tomori",
       tomoriAttributes: selectedPersona.attribute_list,
       tomoriConfig: effectivePersona.config,


### PR DESCRIPTION
Fixed, full bug description from clod:

The snapshot passed to buildContext omits tomoriState. So inside buildContextNative, this line:

 ` const tomoriState = snapshot?.tomoriState ?? (await loadTomoriState(guildId));`

falls back to loadTomoriState(guildId), which always returns the main persona (it queries ORDER BY t.is_alter ASC LIMIT 1). The selected alter is correctly used for nickname/attributes/personaPrompt (passed as explicit params), but everything that goes through the tomoriState path inside buildContextNative — the RAG tomori_id filter, the persona context note, and server memories by lineage — all use the main persona.

The fix is one word — add tomoriState: effectivePersona to the snapshot:

` snapshot: { triggererUserRow: userData, tomoriState: effectivePersona },`

effectivePersona already has the correct LLM override applied (assembled in step 9b), so this is the right object to use, matching exactly what tomoriChat.ts puts in personaSnapshot.
