### PR TITLE
Refactor | Simplify /tool compact roleplay output to scene summary only

### DIFF
--- a/src/commands/tool/compact.ts
+++ b/src/commands/tool/compact.ts
@@ -15,6 +15,7 @@ export const configureSubcommand = (subcommand: SlashCommandSubcommandBuilder) =
         .addChoices(
           { name: localizer("en-US", "commands.tool.compact.modal.type_choice_conversation"), value: "conversation" },
           { name: localizer("en-US", "commands.tool.compact.modal.type_choice_roleplay"), value: "roleplay" },
+          { name: localizer("en-US", "commands.tool.compact.modal.type_choice_manual"), value: "manual" },
         )
         .setRequired(true),
     )

--- a/src/locales/en-US/commands/tool.ts
+++ b/src/locales/en-US/commands/tool.ts
@@ -110,6 +110,9 @@ I have built-in features to help reduce costs from abusers or spammers in your s
         inventory: `Inventory of`,
       },
       refresh_footer: `Context refreshed starting with this embed.`,
+      edit_button_label: `Edit Summary`,
+      edit_modal_title: `Edit Summary`,
+      edit_field_label: `Summary Text`,
     },
     refresh: {
       description: `Clears the recent conversation history.`,

--- a/src/locales/en-US/commands/tool.ts
+++ b/src/locales/en-US/commands/tool.ts
@@ -72,6 +72,8 @@ I have built-in features to help reduce costs from abusers or spammers in your s
         title: `Compact Summary`,
         type_choice_conversation: `Conversation`,
         type_choice_roleplay: `Roleplay`,
+        type_choice_manual: `Manual`,
+        manual_content_label: `Summary / Event`,
         refresh_label: `Refresh Context?`,
         refresh_description: `If Yes, messages above the summary will be ignored.`,
         analyze_images_label: `Analyze Images?`,
@@ -100,6 +102,8 @@ I have built-in features to help reduce costs from abusers or spammers in your s
       summary_title_refreshed: `🧹 Compact Summary (Refreshed)`,
       roleplay_scene_title: `🎭 Roleplay Scene Summary`,
       roleplay_scene_title_refreshed: `🧹 Roleplay Scene Summary (Refreshed)`,
+      manual_entry_title: `📝 Manual Entry`,
+      manual_entry_title_refreshed: `🧹 Manual Entry (Refreshed)`,
       roleplay_scene_synopsis_header: `Synopsis of the current story:`,
       roleplay_character_title_prefix: `🎭 Character Summary:`,
       roleplay_labels: {

--- a/src/locales/en-US/commands/tool.ts
+++ b/src/locales/en-US/commands/tool.ts
@@ -113,6 +113,7 @@ I have built-in features to help reduce costs from abusers or spammers in your s
       edit_button_label: `Edit Summary`,
       edit_modal_title: `Edit Summary`,
       edit_field_label: `Summary Text`,
+      edit_footer: `You have until {deadline} UTC to edit this summary.`,
     },
     refresh: {
       description: `Clears the recent conversation history.`,

--- a/src/locales/ja/commands/tool.ts
+++ b/src/locales/ja/commands/tool.ts
@@ -113,6 +113,7 @@ export default {
       edit_button_label: `要約を編集`,
       edit_modal_title: `要約を編集`,
       edit_field_label: `要約テキスト`,
+      edit_footer: `{deadline} UTC まで要約を編集できます。`,
     },
     refresh: {
       description: `最近の会話履歴をクリアします。`,

--- a/src/locales/ja/commands/tool.ts
+++ b/src/locales/ja/commands/tool.ts
@@ -72,6 +72,8 @@ export default {
         title: `コンパクト要約`,
         type_choice_conversation: `会話`,
         type_choice_roleplay: `ロールプレイ`,
+        type_choice_manual: `手動`,
+        manual_content_label: `要約 / イベント`,
         refresh_label: `コンテキストをリフレッシュ?`,
         refresh_description: `はいの場合、この要約より上のメッセージは無視されます。`,
         analyze_images_label: `画像を解析?`,
@@ -100,6 +102,8 @@ export default {
       summary_title_refreshed: `🧹 コンパクト要約 (リフレッシュ)`,
       roleplay_scene_title: `🎭 ロールプレイのシーン要約`,
       roleplay_scene_title_refreshed: `🧹 ロールプレイのシーン要約 (リフレッシュ)`,
+      manual_entry_title: `📝 手動入力`,
+      manual_entry_title_refreshed: `🧹 手動入力 (リフレッシュ)`,
       roleplay_scene_synopsis_header: `現在のストーリーのあらすじ:`,
       roleplay_character_title_prefix: `🎭 キャラクター要約:`,
       roleplay_labels: {

--- a/src/locales/ja/commands/tool.ts
+++ b/src/locales/ja/commands/tool.ts
@@ -110,6 +110,9 @@ export default {
         inventory: `所持品`,
       },
       refresh_footer: `この埋め込みからコンテキストがリフレッシュされました。`,
+      edit_button_label: `要約を編集`,
+      edit_modal_title: `要約を編集`,
+      edit_field_label: `要約テキスト`,
     },
     refresh: {
       description: `最近の会話履歴をクリアします。`,

--- a/src/providers/google/compactGenerator.ts
+++ b/src/providers/google/compactGenerator.ts
@@ -171,7 +171,7 @@ export async function generateRoleplaySummaryGoogle(
       };
     }
 
-    if (!parsed || typeof parsed.overall_scene_summary !== "string" || !Array.isArray(parsed.characters)) {
+    if (!parsed || typeof parsed.overall_scene_summary !== "string") {
       return { error: "Invalid roleplay summary format from Google" };
     }
 

--- a/src/providers/openrouter/compactGenerator.ts
+++ b/src/providers/openrouter/compactGenerator.ts
@@ -221,7 +221,7 @@ export async function generateRoleplaySummaryOpenrouter(
       };
     }
 
-    if (!parsed || typeof parsed.overall_scene_summary !== "string" || !Array.isArray(parsed.characters)) {
+    if (!parsed || typeof parsed.overall_scene_summary !== "string") {
       return { error: "Invalid roleplay summary format from OpenRouter" };
     }
 

--- a/src/providers/utils/compactCommon.ts
+++ b/src/providers/utils/compactCommon.ts
@@ -20,30 +20,8 @@ export function buildRoleplaySchema() {
     type: "object" as const,
     properties: {
       overall_scene_summary: { type: "string" as const },
-      characters: {
-        type: "array" as const,
-        items: {
-          type: "object" as const,
-          properties: {
-            name: { type: "string" as const },
-            current_goals: { type: "string" as const },
-            emotional_status: { type: "string" as const },
-            physical_status: { type: "string" as const },
-            appearance_clothing: { type: "string" as const },
-            inventory: { type: "string" as const },
-          },
-          required: [
-            "name",
-            "current_goals",
-            "emotional_status",
-            "physical_status",
-            "appearance_clothing",
-            "inventory",
-          ],
-        },
-      },
     },
-    required: ["overall_scene_summary", "characters"],
+    required: ["overall_scene_summary"],
   };
 }
 
@@ -55,14 +33,4 @@ export function buildRoleplaySchema() {
  */
 export const CompactRoleplaySummarySchema = z.object({
   overall_scene_summary: z.string(),
-  characters: z.array(
-    z.object({
-      name: z.string(),
-      current_goals: z.string(),
-      emotional_status: z.string(),
-      physical_status: z.string(),
-      appearance_clothing: z.string(),
-      inventory: z.string(),
-    }),
-  ),
 });

--- a/src/types/misc/compact.ts
+++ b/src/types/misc/compact.ts
@@ -1,4 +1,4 @@
-export type CompactSummaryMode = "conversation" | "roleplay";
+export type CompactSummaryMode = "conversation" | "roleplay" | "manual";
 
 export interface CompactRoleplaySummary {
   overall_scene_summary: string;

--- a/src/types/misc/compact.ts
+++ b/src/types/misc/compact.ts
@@ -1,15 +1,5 @@
 export type CompactSummaryMode = "conversation" | "roleplay";
 
-export interface CompactRoleplayCharacter {
-  name: string;
-  current_goals: string;
-  emotional_status: string;
-  physical_status: string;
-  appearance_clothing: string;
-  inventory: string;
-}
-
 export interface CompactRoleplaySummary {
   overall_scene_summary: string;
-  characters: CompactRoleplayCharacter[];
 }

--- a/src/utils/compaction/compact/commandImplementation.ts
+++ b/src/utils/compaction/compact/commandImplementation.ts
@@ -187,7 +187,8 @@ export async function executeCompactCommand(
     });
 
     collector.on("collect", async (buttonInteraction) => {
-      const currentText = summaryMessage.embeds[0]?.description ?? "";
+      const liveMessage = await buttonInteraction.message.fetch();
+      const currentText = liveMessage.embeds[0]?.description ?? "";
       const editModal = new ModalBuilder()
         .setCustomId("compact_edit_modal")
         .setTitle(localizer(locale, "commands.tool.compact.edit_modal_title"));

--- a/src/utils/compaction/compact/commandImplementation.ts
+++ b/src/utils/compaction/compact/commandImplementation.ts
@@ -170,20 +170,27 @@ export async function executeCompactCommand(
       return;
     }
 
-    const buildEmbed = (text: string) =>
+    const COLLECTOR_DURATION_MS = 10 * 60 * 1000;
+    const deadlineDate = new Date(Date.now() + COLLECTOR_DURATION_MS);
+    const editDeadline = formatDeadline(deadlineDate);
+
+    const buildEmbed = (text: string, deadline?: string) =>
       modalSelection.summaryType === "conversation"
-        ? buildConversationEmbed(locale, text, modalSelection.refresh)
-        : buildRoleplayEmbeds(locale, text, modalSelection.refresh)[0];
+        ? buildConversationEmbed(locale, text, modalSelection.refresh, deadline)
+        : buildRoleplayEmbeds(locale, text, modalSelection.refresh, deadline)[0];
 
     const summaryText = String(result.summary);
     const buttonRow = buildEditSummaryButtonRow(locale);
-    const summaryMessage = await outputChannel.send({ embeds: [buildEmbed(summaryText)], components: [buttonRow] });
+    const summaryMessage = await outputChannel.send({
+      embeds: [buildEmbed(summaryText, editDeadline)],
+      components: [buttonRow],
+    });
     await editSuccess(modalSelection.submitInteraction, locale, targetChannelOption?.id ?? targetThreadId);
 
     const collector = summaryMessage.createMessageComponentCollector({
       componentType: ComponentType.Button,
       filter: (i) => i.customId === COMPACT_EDIT_BUTTON_ID,
-      time: 10 * 60 * 1000,
+      time: COLLECTOR_DURATION_MS,
     });
 
     collector.on("collect", async (buttonInteraction) => {
@@ -209,14 +216,17 @@ export async function executeCompactCommand(
         });
         const newText = submitted.fields.getTextInputValue("compact_edit_text");
         await submitted.deferUpdate();
-        await summaryMessage.edit({ embeds: [buildEmbed(newText)], components: [buttonRow] });
+        await summaryMessage.edit({ embeds: [buildEmbed(newText, editDeadline)], components: [buttonRow] });
       } catch {
         // Modal dismissed or timed out — no action needed
       }
     });
 
     collector.on("end", async () => {
-      await summaryMessage.edit({ components: [] }).catch(() => {});
+      const liveMessage = await summaryMessage.fetch().catch(() => null);
+      if (!liveMessage) return;
+      const currentText = liveMessage.embeds[0]?.description ?? "";
+      await summaryMessage.edit({ embeds: [buildEmbed(currentText)], components: [] }).catch(() => {});
     });
   } catch (error) {
     log.error("Compact summary command failed", error);
@@ -373,6 +383,15 @@ async function editFailure(
       error,
     },
   );
+}
+
+function formatDeadline(date: Date): string {
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const mm = String(date.getUTCMinutes()).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const mo = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const yyyy = String(date.getUTCFullYear());
+  return `${hh}:${mm} ${dd}/${mo}/${yyyy}`;
 }
 
 async function editSuccess(

--- a/src/utils/compaction/compact/commandImplementation.ts
+++ b/src/utils/compaction/compact/commandImplementation.ts
@@ -12,7 +12,7 @@ import { buildConversationContext } from "./historyExtraction";
 import { promptForCompactOptions } from "./modal";
 import { buildConversationEmbed, buildRoleplayEmbeds, isDiscordThreadChannel, sendEmbedsInChunks } from "./rendering";
 import { generateCompactSummary } from "./summaryGeneration";
-import { buildRoleplayAvatarMap, buildSupplementaryContext } from "./supplementaryContext";
+import { buildSupplementaryContext } from "./supplementaryContext";
 import type { SendableChannel } from "./types";
 
 const DISCORD_SNOWFLAKE_PATTERN = /^\d{17,20}$/;
@@ -161,16 +161,8 @@ export async function executeCompactCommand(
         ? [buildConversationEmbed(locale, String(result.summary), modalSelection.refresh)]
         : buildRoleplayEmbeds(
             locale,
-            typeof result.summary === "string"
-              ? { overall_scene_summary: result.summary, characters: [] }
-              : result.summary,
+            typeof result.summary === "string" ? result.summary : result.summary.overall_scene_summary,
             modalSelection.refresh,
-            await buildRoleplayAvatarMap({
-              userIds: context.userIds,
-              client,
-              guild: interaction.guild ?? null,
-              serverDiscId,
-            }),
           );
 
     await sendEmbedsInChunks(outputChannel, embeds);

--- a/src/utils/compaction/compact/commandImplementation.ts
+++ b/src/utils/compaction/compact/commandImplementation.ts
@@ -1,5 +1,13 @@
 import type { ChatInputCommandInteraction, Client, TextBasedChannel } from "discord.js";
-import { EmbedBuilder, MessageFlags } from "discord.js";
+import {
+  ActionRowBuilder,
+  ComponentType,
+  EmbedBuilder,
+  MessageFlags,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from "discord.js";
 import type { UserRow } from "@/types/db/schema";
 import { personaRepository } from "@/utils/db/repositories";
 import { replyInfoEmbed } from "@/utils/discord/ui/embeds";
@@ -10,7 +18,13 @@ import { decryptApiKey } from "@/utils/security/crypto";
 import { localizer } from "@/utils/text/localizer";
 import { buildConversationContext } from "./historyExtraction";
 import { promptForCompactOptions } from "./modal";
-import { buildConversationEmbed, buildRoleplayEmbeds, isDiscordThreadChannel, sendEmbedsInChunks } from "./rendering";
+import {
+  COMPACT_EDIT_BUTTON_ID,
+  buildConversationEmbed,
+  buildEditSummaryButtonRow,
+  buildRoleplayEmbeds,
+  isDiscordThreadChannel,
+} from "./rendering";
 import { generateCompactSummary } from "./summaryGeneration";
 import { buildSupplementaryContext } from "./supplementaryContext";
 import type { SendableChannel } from "./types";
@@ -156,17 +170,53 @@ export async function executeCompactCommand(
       return;
     }
 
-    const embeds =
+    const buildEmbed = (text: string) =>
       modalSelection.summaryType === "conversation"
-        ? [buildConversationEmbed(locale, String(result.summary), modalSelection.refresh)]
-        : buildRoleplayEmbeds(
-            locale,
-            typeof result.summary === "string" ? result.summary : result.summary.overall_scene_summary,
-            modalSelection.refresh,
-          );
+        ? buildConversationEmbed(locale, text, modalSelection.refresh)
+        : buildRoleplayEmbeds(locale, text, modalSelection.refresh)[0];
 
-    await sendEmbedsInChunks(outputChannel, embeds);
+    const summaryText = String(result.summary);
+    const buttonRow = buildEditSummaryButtonRow(locale);
+    const summaryMessage = await outputChannel.send({ embeds: [buildEmbed(summaryText)], components: [buttonRow] });
     await editSuccess(modalSelection.submitInteraction, locale, targetChannelOption?.id ?? targetThreadId);
+
+    const collector = summaryMessage.createMessageComponentCollector({
+      componentType: ComponentType.Button,
+      filter: (i) => i.customId === COMPACT_EDIT_BUTTON_ID,
+      time: 10 * 60 * 1000,
+    });
+
+    collector.on("collect", async (buttonInteraction) => {
+      const currentText = summaryMessage.embeds[0]?.description ?? "";
+      const editModal = new ModalBuilder()
+        .setCustomId("compact_edit_modal")
+        .setTitle(localizer(locale, "commands.tool.compact.edit_modal_title"));
+      const textInput = new TextInputBuilder()
+        .setCustomId("compact_edit_text")
+        .setLabel(localizer(locale, "commands.tool.compact.edit_field_label"))
+        .setStyle(TextInputStyle.Paragraph)
+        .setMaxLength(4000)
+        .setRequired(true)
+        .setValue(currentText.slice(0, 4000));
+      editModal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(textInput));
+      await buttonInteraction.showModal(editModal);
+
+      try {
+        const submitted = await buttonInteraction.awaitModalSubmit({
+          time: 600000,
+          filter: (i) => i.customId === "compact_edit_modal" && i.user.id === buttonInteraction.user.id,
+        });
+        const newText = submitted.fields.getTextInputValue("compact_edit_text");
+        await submitted.deferUpdate();
+        await summaryMessage.edit({ embeds: [buildEmbed(newText)], components: [buttonRow] });
+      } catch {
+        // Modal dismissed or timed out — no action needed
+      }
+    });
+
+    collector.on("end", async () => {
+      await summaryMessage.edit({ components: [] }).catch(() => {});
+    });
   } catch (error) {
     log.error("Compact summary command failed", error);
     await editFailure(

--- a/src/utils/compaction/compact/commandImplementation.ts
+++ b/src/utils/compaction/compact/commandImplementation.ts
@@ -17,11 +17,12 @@ import { providerSupportsFeature } from "@/utils/provider/providerInfoRegistry";
 import { decryptApiKey } from "@/utils/security/crypto";
 import { localizer } from "@/utils/text/localizer";
 import { buildConversationContext } from "./historyExtraction";
-import { promptForCompactOptions } from "./modal";
+import { promptForCompactOptions, promptForManualOptions } from "./modal";
 import {
   COMPACT_EDIT_BUTTON_ID,
   buildConversationEmbed,
   buildEditSummaryButtonRow,
+  buildManualEmbed,
   buildRoleplayEmbeds,
   isDiscordThreadChannel,
 } from "./rendering";
@@ -51,6 +52,11 @@ export async function executeCompactCommand(
   const targetChannelOption = interaction.options.getChannel("channel");
   const targetThreadId = interaction.options.getString("thread")?.trim();
   if (!(await validateDestinationOptions(interaction, locale, targetChannelOption?.id, targetThreadId))) return;
+
+  if (summaryType === "manual") {
+    await executeManualCompact(client, interaction, locale, targetChannelOption, targetThreadId);
+    return;
+  }
 
   const modalSelection = await promptForCompactOptions(interaction, locale, summaryType);
   if (!modalSelection) return;
@@ -383,6 +389,109 @@ async function editFailure(
       error,
     },
   );
+}
+
+async function executeManualCompact(
+  client: Client,
+  interaction: ChatInputCommandInteraction,
+  locale: string,
+  targetChannelOption: ReturnType<ChatInputCommandInteraction["options"]["getChannel"]>,
+  targetThreadId: string | undefined,
+): Promise<void> {
+  const manualSelection = await promptForManualOptions(interaction, locale);
+  if (!manualSelection) return;
+
+  const channel = manualSelection.submitInteraction.channel ?? interaction.channel;
+  if (!channel || !("send" in channel) || typeof channel.send !== "function" || !("messages" in channel)) {
+    await editError(
+      manualSelection.submitInteraction,
+      locale,
+      "general.errors.channel_only_title",
+      "general.errors.channel_only_description",
+    );
+    return;
+  }
+
+  const outputChannel = await resolveOutputChannel(
+    client,
+    interaction.guildId,
+    channel as SendableChannel,
+    targetChannelOption?.id,
+    targetThreadId,
+  );
+  if (!outputChannel) {
+    const titleKey = targetThreadId
+      ? "commands.tool.compact.thread_invalid_title"
+      : "general.errors.channel_only_title";
+    const descriptionKey = targetThreadId
+      ? "commands.tool.compact.thread_invalid_description"
+      : "general.errors.channel_only_description";
+    await editError(manualSelection.submitInteraction, locale, titleKey, descriptionKey);
+    return;
+  }
+
+  try {
+    const COLLECTOR_DURATION_MS = 10 * 60 * 1000;
+    const editDeadline = formatDeadline(new Date(Date.now() + COLLECTOR_DURATION_MS));
+    const buildEmbed = (text: string, deadline?: string) =>
+      buildManualEmbed(locale, text, manualSelection.refresh, deadline);
+
+    const buttonRow = buildEditSummaryButtonRow(locale);
+    const summaryMessage = await outputChannel.send({
+      embeds: [buildEmbed(manualSelection.summaryContent, editDeadline)],
+      components: [buttonRow],
+    });
+    await editSuccess(manualSelection.submitInteraction, locale, targetChannelOption?.id ?? targetThreadId);
+
+    const collector = summaryMessage.createMessageComponentCollector({
+      componentType: ComponentType.Button,
+      filter: (i) => i.customId === COMPACT_EDIT_BUTTON_ID,
+      time: COLLECTOR_DURATION_MS,
+    });
+
+    collector.on("collect", async (buttonInteraction) => {
+      const liveMessage = await buttonInteraction.message.fetch();
+      const currentText = liveMessage.embeds[0]?.description ?? "";
+      const editModal = new ModalBuilder()
+        .setCustomId("compact_edit_modal")
+        .setTitle(localizer(locale, "commands.tool.compact.edit_modal_title"));
+      const textInput = new TextInputBuilder()
+        .setCustomId("compact_edit_text")
+        .setLabel(localizer(locale, "commands.tool.compact.edit_field_label"))
+        .setStyle(TextInputStyle.Paragraph)
+        .setMaxLength(4000)
+        .setRequired(true)
+        .setValue(currentText.slice(0, 4000));
+      editModal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(textInput));
+      await buttonInteraction.showModal(editModal);
+
+      try {
+        const submitted = await buttonInteraction.awaitModalSubmit({
+          time: 600000,
+          filter: (i) => i.customId === "compact_edit_modal" && i.user.id === buttonInteraction.user.id,
+        });
+        const newText = submitted.fields.getTextInputValue("compact_edit_text");
+        await submitted.deferUpdate();
+        await summaryMessage.edit({ embeds: [buildEmbed(newText, editDeadline)], components: [buttonRow] });
+      } catch {
+        // Modal dismissed or timed out — no action needed
+      }
+    });
+
+    collector.on("end", async () => {
+      const liveMessage = await summaryMessage.fetch().catch(() => null);
+      if (!liveMessage) return;
+      const currentText = liveMessage.embeds[0]?.description ?? "";
+      await summaryMessage.edit({ embeds: [buildEmbed(currentText)], components: [] }).catch(() => {});
+    });
+  } catch (error) {
+    log.error("Manual compact command failed", error);
+    await editFailure(
+      manualSelection.submitInteraction,
+      locale,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
 }
 
 function formatDeadline(date: Date): string {

--- a/src/utils/compaction/compact/historyExtraction.ts
+++ b/src/utils/compaction/compact/historyExtraction.ts
@@ -158,13 +158,16 @@ function classifyEmbedTitle(embedTitle: string | null): {
     const isReset =
       embedTitle === localizer(supportedLocale, "commands.tool.refresh.title") ||
       embedTitle === localizer(supportedLocale, "commands.tool.compact.summary_title_refreshed") ||
-      embedTitle === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed");
+      embedTitle === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed") ||
+      embedTitle === localizer(supportedLocale, "commands.tool.compact.manual_entry_title_refreshed");
     const isSystemInjection =
       embedTitle === localizer(supportedLocale, "commands.bot.impersonate.system_title") ||
       embedTitle === localizer(supportedLocale, "commands.tool.compact.summary_title") ||
       embedTitle === localizer(supportedLocale, "commands.tool.compact.summary_title_refreshed") ||
       embedTitle === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title") ||
       embedTitle === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed") ||
+      embedTitle === localizer(supportedLocale, "commands.tool.compact.manual_entry_title") ||
+      embedTitle === localizer(supportedLocale, "commands.tool.compact.manual_entry_title_refreshed") ||
       Boolean(compactCharacterTitlePrefix && embedTitle.startsWith(compactCharacterTitlePrefix));
 
     if (isMemoryLearning || isReminderSet || isReset || isSystemInjection) {

--- a/src/utils/compaction/compact/modal.ts
+++ b/src/utils/compaction/compact/modal.ts
@@ -6,9 +6,14 @@ import { localizer } from "@/utils/text/localizer";
 import type { ModalComponent } from "@/types/discord/modal";
 
 const MODAL_CUSTOM_ID = "tool_compact_modal";
+const MANUAL_MODAL_CUSTOM_ID = "tool_compact_manual_modal";
 const REFRESH_FIELD_ID = "refresh_context";
 const ANALYZE_IMAGES_FIELD_ID = "analyze_images";
 const SYSTEM_PROMPT_FIELD_ID = "system_prompt";
+const MANUAL_CONTENT_FIELD_ID = "manual_content";
+
+const DEFAULT_MANUAL_CONTENT =
+  "Manually enter a summary, scene change, or other event. There will be NO AI summarization or compaction of preceding messages.";
 
 const DEFAULT_CONVERSATION_SYSTEM_PROMPT =
   "You are a skilled conversation analyst who creates clear, readable summaries of Discord conversations. " +
@@ -26,7 +31,7 @@ const DEFAULT_ROLEPLAY_SYSTEM_PROMPT =
   "Your target audience is the AI player, not the human player - consider this when deciding what to summarize and how. " +
   "Your maximum budget is 3500 characters.";
 
-export { DEFAULT_CONVERSATION_SYSTEM_PROMPT, DEFAULT_ROLEPLAY_SYSTEM_PROMPT };
+export { DEFAULT_CONVERSATION_SYSTEM_PROMPT, DEFAULT_ROLEPLAY_SYSTEM_PROMPT, DEFAULT_MANUAL_CONTENT };
 
 export type CompactModalSelection = {
   submitInteraction: ModalSubmitInteraction;
@@ -70,6 +75,56 @@ export async function promptForCompactOptions(
     refresh: (modalResult.multiValues?.[REFRESH_FIELD_ID] ?? []).includes("yes"),
     analyzeImages: (modalResult.multiValues?.[ANALYZE_IMAGES_FIELD_ID] ?? []).includes("yes"),
     systemPrompt: modalResult.values[SYSTEM_PROMPT_FIELD_ID]?.trim() || defaultSystemPrompt,
+  };
+}
+
+export type ManualModalSelection = {
+  submitInteraction: ModalSubmitInteraction;
+  refresh: boolean;
+  summaryContent: string;
+};
+
+export async function promptForManualOptions(
+  interaction: ChatInputCommandInteraction,
+  locale: string,
+): Promise<ManualModalSelection | null> {
+  const modalResult = await promptWithRawModal(
+    interaction,
+    locale,
+    {
+      modalCustomId: MANUAL_MODAL_CUSTOM_ID,
+      modalTitleKey: "commands.tool.compact.modal.title",
+      components: [
+        {
+          kind: "checkboxGroup",
+          customId: REFRESH_FIELD_ID,
+          labelKey: "commands.tool.compact.modal.refresh_label",
+          descriptionKey: "commands.tool.compact.modal.refresh_description",
+          minValues: 0,
+          required: false,
+          options: [{ label: localizer(locale, "general.yes"), value: "yes" }],
+        },
+        {
+          customId: MANUAL_CONTENT_FIELD_ID,
+          labelKey: "commands.tool.compact.modal.manual_content_label",
+          required: false,
+          style: TextInputStyle.Paragraph,
+          maxLength: 4000,
+          value: DEFAULT_MANUAL_CONTENT,
+        },
+      ],
+    },
+    MessageFlags.Ephemeral,
+  );
+
+  if (modalResult.outcome !== "submit") return null;
+  const submitInteraction = modalResult.interaction;
+  if (!submitInteraction || !modalResult.values) return null;
+
+  return {
+    submitInteraction,
+    refresh: (modalResult.multiValues?.[REFRESH_FIELD_ID] ?? []).includes("yes"),
+    summaryContent: modalResult.values[MANUAL_CONTENT_FIELD_ID]?.trim() || DEFAULT_MANUAL_CONTENT,
   };
 }
 

--- a/src/utils/compaction/compact/modal.ts
+++ b/src/utils/compaction/compact/modal.ts
@@ -19,13 +19,11 @@ const DEFAULT_CONVERSATION_SYSTEM_PROMPT =
 
 const DEFAULT_ROLEPLAY_SYSTEM_PROMPT =
   "You are a skilled storyteller who crafts clear, engaging summaries of roleplay scenes. " +
-  "Analyze the roleplay narrative and produce a structured JSON summary that captures the scene and each character's current state. " +
-  "Write with clarity and literary quality: your descriptions should paint a vivid picture while remaining concise. " +
-  "Base every detail on what's actually present in the context; if something isn't shown, mark it as 'Unknown' or 'Not specified'. " +
-  "Keep each field brief but evocative: think short phrases or 2-3 well-crafted sentences that tell the story.\n\n" +
-  "The JSON structure should contain:\n" +
-  "- overall_scene_summary: A narrative overview of the current scene, setting, atmosphere, and what's happening\n" +
-  "- characters: An array where each character has name, current_goals, emotional_status, physical_status, appearance_clothing, and inventory";
+  "Analyze the roleplay narrative and produce a structured JSON summary that captures the scene. " +
+  "Write with clarity and literary quality: your description should paint a vivid picture while remaining concise. " +
+  "Base every detail on what's actually present in the context; if something isn't shown, note that it is unclear. " +
+  "The JSON structure should contain a single field:\n" +
+  "- overall_scene_summary: A narrative overview of the current scene, setting, atmosphere, and what's happening";
 
 export { DEFAULT_CONVERSATION_SYSTEM_PROMPT, DEFAULT_ROLEPLAY_SYSTEM_PROMPT };
 

--- a/src/utils/compaction/compact/modal.ts
+++ b/src/utils/compaction/compact/modal.ts
@@ -18,12 +18,13 @@ const DEFAULT_CONVERSATION_SYSTEM_PROMPT =
   "Be concise but thorough: every sentence should add value. Output plain text only.";
 
 const DEFAULT_ROLEPLAY_SYSTEM_PROMPT =
-  "You are a skilled storyteller who crafts clear, engaging summaries of roleplay scenes. " +
-  "Analyze the roleplay narrative and produce a structured JSON summary that captures the scene. " +
-  "Write with clarity and literary quality: your description should paint a vivid picture while remaining concise. " +
-  "Base every detail on what's actually present in the context; if something isn't shown, note that it is unclear. " +
-  "The JSON structure should contain a single field:\n" +
-  "- overall_scene_summary: A narrative overview of the current scene, setting, atmosphere, and what's happening";
+  "You are producing a summary of this AI-enabled roleplay session in order to shorten the context submitted to the AI in future messages. " +
+  "Analyze the roleplay narrative and produce a structured summary which captures necessary elements to provide narrative and character coherency going forward. " +
+  "Write with clarity, and structure the summary as appropriate for the material presented. " +
+  "Your description should be complete while remaining quite concise. " +
+  "If something is unclear, note this rather than attempting to resolve it. " +
+  "Your target audience is the AI player, not the human player - consider this when deciding what to summarize and how. " +
+  "Your maximum budget is 3500 characters.";
 
 export { DEFAULT_CONVERSATION_SYSTEM_PROMPT, DEFAULT_ROLEPLAY_SYSTEM_PROMPT };
 

--- a/src/utils/compaction/compact/rendering.ts
+++ b/src/utils/compaction/compact/rendering.ts
@@ -1,4 +1,4 @@
-import { ChannelType, EmbedBuilder } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, ChannelType, EmbedBuilder } from "discord.js";
 import { ColorCode } from "@/utils/misc/logger";
 import { localizer } from "@/utils/text/localizer";
 import type { SendableChannel } from "./types";
@@ -54,6 +54,16 @@ export async function sendEmbedsInChunks(channel: SendableChannel, embeds: Embed
   for (let index = 0; index < embeds.length; index += chunkSize) {
     await channel.send({ embeds: embeds.slice(index, index + chunkSize) });
   }
+}
+
+export const COMPACT_EDIT_BUTTON_ID = "compact_edit_summary";
+
+export function buildEditSummaryButtonRow(locale: string): ActionRowBuilder<ButtonBuilder> {
+  const button = new ButtonBuilder()
+    .setCustomId(COMPACT_EDIT_BUTTON_ID)
+    .setLabel(localizer(locale, "commands.tool.compact.edit_button_label"))
+    .setStyle(ButtonStyle.Secondary);
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(button);
 }
 
 function truncateEmbedDescription(text: string, maxLength = 4000): string {

--- a/src/utils/compaction/compact/rendering.ts
+++ b/src/utils/compaction/compact/rendering.ts
@@ -1,5 +1,4 @@
 import { ChannelType, EmbedBuilder } from "discord.js";
-import type { CompactRoleplaySummary } from "@/types/misc/compact";
 import { ColorCode } from "@/utils/misc/logger";
 import { localizer } from "@/utils/text/localizer";
 import type { SendableChannel } from "./types";
@@ -21,48 +20,21 @@ export function buildConversationEmbed(locale: string, summaryText: string, refr
   return embed;
 }
 
-export function buildRoleplayEmbeds(
-  locale: string,
-  summary: CompactRoleplaySummary,
-  refresh: boolean,
-  avatarMap?: Map<string, string>,
-): EmbedBuilder[] {
-  const sceneTitle = refresh
+export function buildRoleplayEmbeds(locale: string, summaryText: string, refresh: boolean): EmbedBuilder[] {
+  const title = refresh
     ? localizer(locale, "commands.tool.compact.roleplay_scene_title_refreshed")
     : localizer(locale, "commands.tool.compact.roleplay_scene_title");
-  const sceneDescription = `## ${localizer(locale, "commands.tool.compact.roleplay_scene_synopsis_header")}\n${summary.overall_scene_summary}`;
-  const sceneEmbed = new EmbedBuilder()
-    .setTitle(sceneTitle)
-    .setDescription(truncateEmbedDescription(sceneDescription))
+
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(truncateEmbedDescription(summaryText))
     .setColor(ColorCode.SECTION);
 
   if (refresh) {
-    sceneEmbed.setFooter({ text: localizer(locale, "commands.tool.compact.refresh_footer") });
+    embed.setFooter({ text: localizer(locale, "commands.tool.compact.refresh_footer") });
   }
 
-  const embeds = [sceneEmbed];
-  const fuzzyAvatarMap = buildFuzzyAvatarMap(avatarMap);
-  const characterPrefix = localizer(locale, "commands.tool.compact.roleplay_character_title_prefix");
-
-  for (const character of summary.characters) {
-    const name = character.name || "Unknown";
-    const lines = [
-      `**${localizer(locale, "commands.tool.compact.roleplay_labels.current_goals")} ${name}**: ${character.current_goals || "Unknown"}`,
-      `**${localizer(locale, "commands.tool.compact.roleplay_labels.emotional_status")} ${name}**: ${character.emotional_status || "Unknown"}`,
-      `**${localizer(locale, "commands.tool.compact.roleplay_labels.physical_status")} ${name}**: ${character.physical_status || "Unknown"}`,
-      `**${localizer(locale, "commands.tool.compact.roleplay_labels.appearance_clothing")} ${name}**: ${character.appearance_clothing || "Unknown"}`,
-      `**${localizer(locale, "commands.tool.compact.roleplay_labels.inventory")} ${name}**: ${character.inventory || "Unknown"}`,
-    ];
-    const embed = new EmbedBuilder()
-      .setTitle(`${characterPrefix} ${name}`)
-      .setDescription(truncateEmbedDescription(lines.join("\n")))
-      .setColor(ColorCode.SECTION);
-    const avatarUrl = resolveCharacterAvatar(name, avatarMap, fuzzyAvatarMap);
-    if (avatarUrl) embed.setThumbnail(avatarUrl);
-    embeds.push(embed);
-  }
-
-  return embeds;
+  return [embed];
 }
 
 export function isDiscordThreadChannel(channel: unknown): boolean {
@@ -88,42 +60,3 @@ function truncateEmbedDescription(text: string, maxLength = 4000): string {
   return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
 }
 
-function buildFuzzyAvatarMap(avatarMap?: Map<string, string>): Map<string, string> {
-  const fuzzyAvatarMap = new Map<string, string>();
-  if (!avatarMap) return fuzzyAvatarMap;
-
-  for (const [nameKey, url] of avatarMap) {
-    const normalized = normalizeNameForMatch(nameKey);
-    if (normalized && !fuzzyAvatarMap.has(normalized)) fuzzyAvatarMap.set(normalized, url);
-  }
-  return fuzzyAvatarMap;
-}
-
-function resolveCharacterAvatar(
-  characterName: string,
-  avatarMap?: Map<string, string>,
-  fuzzyAvatarMap = new Map<string, string>(),
-): string | undefined {
-  let avatarUrl = avatarMap?.get(characterName.trim().toLowerCase());
-  const normalized = normalizeNameForMatch(characterName);
-  if (!avatarUrl && normalized) avatarUrl = fuzzyAvatarMap.get(normalized);
-  if (avatarUrl || !normalized || normalized.length < 3) return avatarUrl;
-
-  let bestMatchKey = "";
-  for (const [key, url] of fuzzyAvatarMap.entries()) {
-    if (key.length < 3) continue;
-    if ((normalized.includes(key) || key.includes(normalized)) && key.length > bestMatchKey.length) {
-      bestMatchKey = key;
-      avatarUrl = url;
-    }
-  }
-  return avatarUrl;
-}
-
-function normalizeNameForMatch(value: string): string {
-  return value
-    .replace(/\([^)]*\)/g, " ")
-    .replace(/[^\p{L}\p{N}]+/gu, " ")
-    .trim()
-    .toLowerCase();
-}

--- a/src/utils/compaction/compact/rendering.ts
+++ b/src/utils/compaction/compact/rendering.ts
@@ -72,6 +72,27 @@ export async function sendEmbedsInChunks(channel: SendableChannel, embeds: Embed
   }
 }
 
+export function buildManualEmbed(
+  locale: string,
+  summaryText: string,
+  refresh: boolean,
+  editDeadline?: string,
+): EmbedBuilder {
+  const title = refresh
+    ? localizer(locale, "commands.tool.compact.manual_entry_title_refreshed")
+    : localizer(locale, "commands.tool.compact.manual_entry_title");
+
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(truncateEmbedDescription(summaryText))
+    .setColor(ColorCode.SECTION);
+
+  const footerText = buildFooterText(locale, refresh, editDeadline);
+  if (footerText) embed.setFooter({ text: footerText });
+
+  return embed;
+}
+
 export const COMPACT_EDIT_BUTTON_ID = "compact_edit_summary";
 
 export function buildEditSummaryButtonRow(locale: string): ActionRowBuilder<ButtonBuilder> {

--- a/src/utils/compaction/compact/rendering.ts
+++ b/src/utils/compaction/compact/rendering.ts
@@ -48,8 +48,7 @@ export function buildRoleplayEmbeds(
 function buildFooterText(locale: string, refresh: boolean, editDeadline?: string): string {
   const parts: string[] = [];
   if (refresh) parts.push(localizer(locale, "commands.tool.compact.refresh_footer"));
-  if (editDeadline)
-    parts.push(localizer(locale, "commands.tool.compact.edit_footer", { deadline: editDeadline }));
+  if (editDeadline) parts.push(localizer(locale, "commands.tool.compact.edit_footer", { deadline: editDeadline }));
   return parts.join(" · ");
 }
 
@@ -106,4 +105,3 @@ export function buildEditSummaryButtonRow(locale: string): ActionRowBuilder<Butt
 function truncateEmbedDescription(text: string, maxLength = 4000): string {
   return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
 }
-

--- a/src/utils/compaction/compact/rendering.ts
+++ b/src/utils/compaction/compact/rendering.ts
@@ -3,7 +3,12 @@ import { ColorCode } from "@/utils/misc/logger";
 import { localizer } from "@/utils/text/localizer";
 import type { SendableChannel } from "./types";
 
-export function buildConversationEmbed(locale: string, summaryText: string, refresh: boolean): EmbedBuilder {
+export function buildConversationEmbed(
+  locale: string,
+  summaryText: string,
+  refresh: boolean,
+  editDeadline?: string,
+): EmbedBuilder {
   const title = refresh
     ? localizer(locale, "commands.tool.compact.summary_title_refreshed")
     : localizer(locale, "commands.tool.compact.summary_title");
@@ -13,14 +18,18 @@ export function buildConversationEmbed(locale: string, summaryText: string, refr
     .setDescription(truncateEmbedDescription(summaryText))
     .setColor(ColorCode.SECTION);
 
-  if (refresh) {
-    embed.setFooter({ text: localizer(locale, "commands.tool.compact.refresh_footer") });
-  }
+  const footerText = buildFooterText(locale, refresh, editDeadline);
+  if (footerText) embed.setFooter({ text: footerText });
 
   return embed;
 }
 
-export function buildRoleplayEmbeds(locale: string, summaryText: string, refresh: boolean): EmbedBuilder[] {
+export function buildRoleplayEmbeds(
+  locale: string,
+  summaryText: string,
+  refresh: boolean,
+  editDeadline?: string,
+): EmbedBuilder[] {
   const title = refresh
     ? localizer(locale, "commands.tool.compact.roleplay_scene_title_refreshed")
     : localizer(locale, "commands.tool.compact.roleplay_scene_title");
@@ -30,11 +39,18 @@ export function buildRoleplayEmbeds(locale: string, summaryText: string, refresh
     .setDescription(truncateEmbedDescription(summaryText))
     .setColor(ColorCode.SECTION);
 
-  if (refresh) {
-    embed.setFooter({ text: localizer(locale, "commands.tool.compact.refresh_footer") });
-  }
+  const footerText = buildFooterText(locale, refresh, editDeadline);
+  if (footerText) embed.setFooter({ text: footerText });
 
   return [embed];
+}
+
+function buildFooterText(locale: string, refresh: boolean, editDeadline?: string): string {
+  const parts: string[] = [];
+  if (refresh) parts.push(localizer(locale, "commands.tool.compact.refresh_footer"));
+  if (editDeadline)
+    parts.push(localizer(locale, "commands.tool.compact.edit_footer", { deadline: editDeadline }));
+  return parts.join(" · ");
 }
 
 export function isDiscordThreadChannel(channel: unknown): boolean {

--- a/src/utils/compaction/compact/summaryGeneration.ts
+++ b/src/utils/compaction/compact/summaryGeneration.ts
@@ -1,7 +1,4 @@
-import {
-  generateConversationSummaryForProvider,
-  generateRoleplaySummaryForProvider,
-} from "@/providers/utils/providerFeatureExecutors";
+import { generateConversationSummaryForProvider } from "@/providers/utils/providerFeatureExecutors";
 import type { CompactSummaryMode } from "@/types/misc/compact";
 import { log } from "@/utils/misc/logger";
 import type { ConversationContext } from "./types";
@@ -49,25 +46,15 @@ export async function generateCompactSummary(params: {
     ? params.context.imageReferences.map((img) => ({ url: img.url, mimeType: img.mimeType }))
     : undefined;
 
-  return params.summaryType === "conversation"
-    ? await generateConversationSummaryForProvider({
-        providerName: params.providerName,
-        apiKey: params.apiKey,
-        model: params.model,
-        endpointUrl: params.endpointUrl,
-        systemPrompt: prompt.systemPrompt,
-        userPrompt: prompt.userPrompt,
-        images,
-      })
-    : await generateRoleplaySummaryForProvider({
-        providerName: params.providerName,
-        apiKey: params.apiKey,
-        model: params.model,
-        endpointUrl: params.endpointUrl,
-        systemPrompt: prompt.systemPrompt,
-        userPrompt: prompt.userPrompt,
-        images,
-      });
+  return await generateConversationSummaryForProvider({
+    providerName: params.providerName,
+    apiKey: params.apiKey,
+    model: params.model,
+    endpointUrl: params.endpointUrl,
+    systemPrompt: prompt.systemPrompt,
+    userPrompt: prompt.userPrompt,
+    images,
+  });
 }
 
 function buildPrompt(params: {

--- a/src/utils/compaction/compact/supplementaryContext.ts
+++ b/src/utils/compaction/compact/supplementaryContext.ts
@@ -1,9 +1,6 @@
-import type { Client, Guild } from "discord.js";
 import { PrivacyLevel } from "@/types/db/schema";
 import { getCachedBlacklistStatus, getCachedPrivacyLevel, getCachedUserRow } from "@/utils/cache/userCache";
 import { personaRepository, personalMemoryRepository } from "@/utils/db/repositories";
-import { resolvePersonaAvatarURL } from "@/utils/discord/webhook/identity";
-import { resolvePersonaAvatarPublicUrl } from "@/utils/storage/avatarStorage";
 
 export async function buildSupplementaryContext(params: {
   serverDiscId: string;
@@ -45,20 +42,6 @@ export async function buildSupplementaryContext(params: {
   return sections.join("\n\n");
 }
 
-export async function buildRoleplayAvatarMap(params: {
-  userIds: string[];
-  client: Client;
-  guild?: Guild | null;
-  serverDiscId: string;
-}): Promise<Map<string, string>> {
-  const avatarMap = await buildUserAvatarMap(params);
-  const personaAvatarMap = await buildPersonaAvatarMap(params.serverDiscId, params.guild ?? null);
-  for (const [key, value] of personaAvatarMap) {
-    avatarMap.set(key, value);
-  }
-  return avatarMap;
-}
-
 async function buildUserMemoryLines(serverDiscId: string, userIds: string[], lineageId: number): Promise<string[]> {
   const userMemoryLines: string[] = [];
   for (const userId of userIds) {
@@ -79,56 +62,3 @@ async function buildUserMemoryLines(serverDiscId: string, userIds: string[], lin
   return userMemoryLines;
 }
 
-async function buildPersonaAvatarMap(serverDiscId: string, guild?: Guild | null): Promise<Map<string, string>> {
-  const personas = await personaRepository.loadAllForServer(serverDiscId);
-  const avatarMap = new Map<string, string>();
-  for (const persona of personas) {
-    const avatarUrl = guild
-      ? resolvePersonaAvatarURL(persona, guild)
-      : persona.webhook_avatar_url
-        ? (resolvePersonaAvatarPublicUrl(persona.webhook_avatar_url) ?? undefined)
-        : undefined;
-    const nameKey = persona.persona_nickname?.trim().toLowerCase();
-    if (avatarUrl && nameKey) avatarMap.set(nameKey, avatarUrl);
-  }
-  return avatarMap;
-}
-
-async function buildUserAvatarMap(params: {
-  userIds: string[];
-  client: Client;
-  guild?: Guild | null;
-}): Promise<Map<string, string>> {
-  const avatarMap = new Map<string, string>();
-  for (const userId of params.userIds) {
-    const member = params.guild ? await params.guild.members.fetch(userId).catch(() => null) : null;
-    const user = member?.user ?? (await params.client.users.fetch(userId).catch(() => null));
-    if (!user) continue;
-
-    const avatarUrl =
-      member?.displayAvatarURL({ extension: "png", size: 256, forceStatic: true }) ??
-      user.displayAvatarURL({ extension: "png", size: 256, forceStatic: true });
-    if (!isValidHttpUrl(avatarUrl)) continue;
-
-    const userRow = await getCachedUserRow(userId);
-    const nameCandidates = [
-      member?.displayName,
-      member?.nickname,
-      user.globalName,
-      user.username,
-      userRow?.user_nickname,
-    ]
-      .filter((value): value is string => Boolean(value?.trim()))
-      .map((value) => value.trim().toLowerCase());
-    for (const name of nameCandidates) {
-      if (!avatarMap.has(name)) avatarMap.set(name, avatarUrl);
-    }
-  }
-  return avatarMap;
-}
-
-function isValidHttpUrl(url: string): boolean {
-  if (!URL.canParse(url)) return false;
-  const parsed = new URL(url);
-  return parsed.protocol === "http:" || parsed.protocol === "https:";
-}

--- a/src/utils/compaction/compact/supplementaryContext.ts
+++ b/src/utils/compaction/compact/supplementaryContext.ts
@@ -61,4 +61,3 @@ async function buildUserMemoryLines(serverDiscId: string, userIds: string[], lin
   }
   return userMemoryLines;
 }
-

--- a/src/utils/compaction/compact/types.ts
+++ b/src/utils/compaction/compact/types.ts
@@ -1,4 +1,4 @@
-import type { EmbedBuilder, Message } from "discord.js";
+import type { ActionRowBuilder, ButtonBuilder, EmbedBuilder, Message } from "discord.js";
 
 export type ImageReference = {
   label: string;
@@ -14,5 +14,5 @@ export type ConversationContext = {
 };
 
 export type SendableChannel = {
-  send: (options: { embeds: EmbedBuilder[] }) => Promise<Message>;
+  send: (options: { embeds: EmbedBuilder[]; components?: ActionRowBuilder<ButtonBuilder>[] }) => Promise<Message>;
 };

--- a/src/utils/discord/embedClassifier.ts
+++ b/src/utils/discord/embedClassifier.ts
@@ -99,17 +99,23 @@ export function checkTargetEmbedTitle(embedTitle: string | null | undefined): Ta
       return { isTarget: true, type: "punish" };
     }
 
-    // 4. Compact summary (conversation + scene) and compact refresh variants
+    // 4. Compact summary (conversation + scene + manual) and compact refresh variants
     const compactSummaryTitle = localizer(supportedLocale, "commands.tool.compact.summary_title");
     const compactSummaryRefreshed = localizer(supportedLocale, "commands.tool.compact.summary_title_refreshed");
     const compactSceneTitle = localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title");
     const compactSceneRefreshed = localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed");
+    const compactManualTitle = localizer(supportedLocale, "commands.tool.compact.manual_entry_title");
+    const compactManualRefreshed = localizer(supportedLocale, "commands.tool.compact.manual_entry_title_refreshed");
     const compactCharacterPrefix = localizer(supportedLocale, "commands.tool.compact.roleplay_character_title_prefix");
 
-    if (embedTitle === compactSummaryTitle || embedTitle === compactSceneTitle) {
+    if (embedTitle === compactSummaryTitle || embedTitle === compactSceneTitle || embedTitle === compactManualTitle) {
       return { isTarget: true, type: "compact_summary" };
     }
-    if (embedTitle === compactSummaryRefreshed || embedTitle === compactSceneRefreshed) {
+    if (
+      embedTitle === compactSummaryRefreshed ||
+      embedTitle === compactSceneRefreshed ||
+      embedTitle === compactManualRefreshed
+    ) {
       return { isTarget: true, type: "compact_refresh" };
     }
     if (compactCharacterPrefix && embedTitle.startsWith(compactCharacterPrefix)) {

--- a/src/utils/discord/embedDetection.ts
+++ b/src/utils/discord/embedDetection.ts
@@ -35,6 +35,10 @@ export function isRefreshMarkerEmbed(embed: Embed): boolean {
     // 3. Check for compact roleplay scene refreshed title
     const compactSceneRefreshed = localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed");
     if (title === compactSceneRefreshed) return true;
+
+    // 4. Check for compact manual entry refreshed title
+    const compactManualRefreshed = localizer(supportedLocale, "commands.tool.compact.manual_entry_title_refreshed");
+    if (title === compactManualRefreshed) return true;
   }
 
   return false;
@@ -69,10 +73,11 @@ export function classifyRefreshMarkerEmbed(embed: Embed): "reset" | "compact_ref
     if (title === localizer(supportedLocale, "commands.tool.refresh.title")) {
       return "reset";
     }
-    // 2. Compact refresh markers — either summary or scene refresh
+    // 2. Compact refresh markers — summary, scene, or manual refresh
     if (
       title === localizer(supportedLocale, "commands.tool.compact.summary_title_refreshed") ||
-      title === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed")
+      title === localizer(supportedLocale, "commands.tool.compact.roleplay_scene_title_refreshed") ||
+      title === localizer(supportedLocale, "commands.tool.compact.manual_entry_title_refreshed")
     ) {
       return "compact_refresh";
     }


### PR DESCRIPTION
## Summary
Substantial rework of "/tool compact" I/O

1. Default prompts exposed for user editing, roleplay default prompt rewritten
2. No more forced JSON output; prompt will determine structure
3. Summary can be edited for 10 minutes after embed creation, expiry time noted at bottom of embed
4. Added manual mode that bypasses AI compaction

## Type(s)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor / Chore

## Quality Gates
- [ ] `bun run vl` output shows no critical failures
- [ ] (If adding or modifying a Discord Command) Followed command patterns and conventions in [`docs/subsystems/command-system.md`](../docs/subsystems/command-system.md) 
**- [ ] No hardcoded operational limits/timeouts (use env vars, document in `.env.optional.example`) SEE BELOW**

## Testing
tested on Discord,works

## Reviewer Notes
Went with a 10 minute edit timeout because that seems to be a Discord best practice to prevent future griefing. It's clearly noted in the embed.
I didn't touch the default conversation prompt because I don't have good test data for it. The default roleplay prompt seems to work well for narrative/character stuff with different tones, if people are gamifying and want stat/consumable tracking etc they can write their own use-case-specific prompts.
Left dead code for provider processing (generateRoleplaySummaryAnthropic etc) as a reference if required

