### PR TITLE
Derive deliberate tool retention from recent messages

### DIFF
--- a/src/utils/chat/contextPipeline.ts
+++ b/src/utils/chat/contextPipeline.ts
@@ -10,11 +10,11 @@ import { normalizeMessageFetchLimit } from "@/utils/discord/messageFetchLimit";
 import { log } from "@/utils/misc/logger";
 import { hasExplicitLongTermMemoryIntent } from "@/utils/memory/explicitLongTermMemoryIntent";
 import {
-  consumeRetainedToolAffordanceNames,
   type DeliberateToolIntentMatch,
   getDeliberateToolIntentResult,
   getFollowUpToolIntentResult,
   getRecentToolAffordanceNames,
+  getRecentTriggeredToolIntentResult,
   resolveDeliberateToolContextTurns,
   resolveDeliberateToolMode,
 } from "@/utils/tools/deliberateToolMode";
@@ -173,25 +173,33 @@ export async function buildChatTurnContext(turn: ChatTurn): Promise<ChatTurnCont
   );
   const deliberateToolAllowedNames = [...deliberateToolIntentResult.allowedToolNames];
   const deliberateToolTriggerMatches: DeliberateToolIntentMatch[] = [...deliberateToolIntentResult.matches];
+  const deliberateToolContextTurns = resolveDeliberateToolContextTurns(
+    turn.persona.config.deliberate_tool_context_turns,
+  );
 
   const followUpToolIntentResult = getFollowUpToolIntentResult(
     deliberateToolIntentText,
-    getRecentToolAffordanceNames(history.rawMessages, message.id, client.user?.id),
+    getRecentToolAffordanceNames(
+      history.rawMessages,
+      message.id,
+      turn.persona.config.deliberate_tool_triggers,
+      client.user?.id,
+    ),
   );
   deliberateToolAllowedNames.push(...followUpToolIntentResult.allowedToolNames);
   deliberateToolAllowedNames.push(...(streamingContext.endTurnAfterTools ?? []));
   deliberateToolTriggerMatches.push(...followUpToolIntentResult.matches);
 
-  const retainedToolNames = consumeRetainedToolAffordanceNames(channel.id);
+  const recentTriggeredToolIntentResult = getRecentTriggeredToolIntentResult(
+    history.rawMessages,
+    message.id,
+    turn.persona.config.deliberate_tool_triggers,
+    deliberateToolContextTurns,
+    client.user?.id,
+  );
   if (deliberateToolModeActive) {
-    deliberateToolAllowedNames.push(...retainedToolNames);
-    deliberateToolTriggerMatches.push(
-      ...retainedToolNames.map((toolName) => ({
-        toolName,
-        trigger: "recent successful tool",
-        source: "follow-up" as const,
-      })),
-    );
+    deliberateToolAllowedNames.push(...recentTriggeredToolIntentResult.allowedToolNames);
+    deliberateToolTriggerMatches.push(...recentTriggeredToolIntentResult.matches);
   }
 
   // 2. Reminder-driven adjustments: voice/audio reminders should auto-expose
@@ -327,10 +335,6 @@ export async function buildChatTurnContext(turn: ChatTurn): Promise<ChatTurnCont
     hasVisionTool: !!effectivePersona.vision_llm && !(effectiveSeesImages ?? effectivePersona.llm.sees_images),
     messageIdMap,
   });
-
-  const deliberateToolContextTurns = resolveDeliberateToolContextTurns(
-    effectivePersona.config.deliberate_tool_context_turns,
-  );
 
   const contextItems = appendTailDirectives({
     turn,

--- a/src/utils/chat/toolLoop.ts
+++ b/src/utils/chat/toolLoop.ts
@@ -6,7 +6,6 @@ import { sendStandardEmbed } from "@/utils/discord/embedHelper";
 import { routeHiddenToolNotice } from "@/utils/discord/toolProgressNotice";
 import { ColorCode, log } from "@/utils/misc/logger";
 import { providerUsesApiFamily } from "@/utils/provider/providerInfoRegistry";
-import { retainSuccessfulToolAffordance } from "@/utils/tools/deliberateToolMode";
 import {
   channelLocks,
   getChannelTurnAbortSignal,
@@ -338,14 +337,10 @@ async function executeToolCall(
         deliberateAllowedSet ? [...deliberateAllowedSet].join(", ") : ""
       }`,
     );
-  } else if (toolResult.success) {
-    // 2. Retain successful tool affordance so short follow-up turns ("do it
-    // again", "one more") keep the same tool exposed for N additional turns.
-    retainSuccessfulToolAffordance(params.context.channel.id, functionName, params.context.deliberateToolContextTurns);
   }
   log.info(`Function call completed: ${functionName} (${Date.now() - startedAt}ms)`);
 
-  // 3. When deliberate-tool-mode admitted the tool via a specific trigger,
+  // 2. When deliberate-tool-mode admitted the tool via a specific trigger,
   // post a hidden notice (thought-log only) explaining why it fired.
   const deliberateToolTriggerMatch = params.context.deliberateToolTriggerMatchByToolName.get(functionName);
   if (params.context.deliberateToolModeActive && deliberateToolTriggerMatch && !isBlockedByDeliberateAllowlist) {

--- a/src/utils/tools/deliberateToolMode.ts
+++ b/src/utils/tools/deliberateToolMode.ts
@@ -618,6 +618,7 @@ export function resolveDeliberateToolMode(
 export function getRecentToolAffordanceNames(
   recentMessages: Message[],
   currentMessageId: string,
+  customTriggers?: DeliberateToolTriggerMap | null,
   clientUserId?: string | null,
 ): string[] {
   const toolNames: string[] = [];
@@ -631,7 +632,7 @@ export function getRecentToolAffordanceNames(
     const isPersonaOutput = Boolean(msg.webhookId) || (Boolean(clientUserId) && msg.author.id === clientUserId);
 
     if (!isPersonaOutput) {
-      const recentIntentResult = getDeliberateToolIntentResult(msg.content);
+      const recentIntentResult = getDeliberateToolIntentResult(msg.content, customTriggers);
       toolNames.push(...recentIntentResult.allowedToolNames);
       if (toolNames.length > 0) break;
       continue;
@@ -657,42 +658,42 @@ export function getRecentToolAffordanceNames(
   return Array.from(new Set(toolNames));
 }
 
-type RetainedToolAffordance = {
-  remainingTurns: number;
-};
-
-// Channel-keyed in-memory store of tool names that should remain exposed for
-// the next N turns after a successful invocation. Counter decrements each
-// consume; entries self-evict at zero.
-const retainedToolAffordancesByChannel = new Map<string, Map<string, RetainedToolAffordance>>();
-
-export function retainSuccessfulToolAffordance(channelId: string, toolName: string, turns: number): void {
-  if (turns <= 0) return;
-
-  let channelAffordances = retainedToolAffordancesByChannel.get(channelId);
-  if (!channelAffordances) {
-    channelAffordances = new Map<string, RetainedToolAffordance>();
-    retainedToolAffordancesByChannel.set(channelId, channelAffordances);
+export function getRecentTriggeredToolIntentResult(
+  recentMessages: Message[],
+  currentMessageId: string,
+  customTriggers: DeliberateToolTriggerMap | null | undefined,
+  lookbackMessageCount: number,
+  clientUserId?: string | null,
+): DeliberateToolIntentResult {
+  if (lookbackMessageCount <= 0) {
+    return { allowedToolNames: [], matches: [] };
   }
 
-  channelAffordances.set(toolName, { remainingTurns: turns });
-}
+  const allowedToolNames: string[] = [];
+  const matches: DeliberateToolIntentMatch[] = [];
+  const lookbackMessages = recentMessages
+    .filter((recentMessage) => recentMessage.id !== currentMessageId)
+    .slice(-lookbackMessageCount);
 
-export function consumeRetainedToolAffordanceNames(channelId: string): string[] {
-  const channelAffordances = retainedToolAffordancesByChannel.get(channelId);
-  if (!channelAffordances) return [];
+  for (const msg of lookbackMessages) {
+    const isPersonaOutput = Boolean(msg.webhookId) || (Boolean(clientUserId) && msg.author.id === clientUserId);
+    if (msg.author.bot || isPersonaOutput) continue;
 
-  const toolNames = [...channelAffordances.keys()];
-  for (const [toolName, affordance] of channelAffordances.entries()) {
-    affordance.remainingTurns -= 1;
-    if (affordance.remainingTurns <= 0) {
-      channelAffordances.delete(toolName);
-    }
+    const recentIntentResult = getDeliberateToolIntentResult(msg.content, customTriggers);
+    allowedToolNames.push(...recentIntentResult.allowedToolNames);
+    matches.push(
+      ...recentIntentResult.matches.map((match) => ({
+        ...match,
+        trigger: `recent message: ${match.trigger}`,
+        source: "follow-up" as const,
+      })),
+    );
   }
 
-  if (channelAffordances.size === 0) {
-    retainedToolAffordancesByChannel.delete(channelId);
-  }
-
-  return toolNames;
+  return {
+    allowedToolNames: Array.from(new Set(allowedToolNames)),
+    matches: Array.from(
+      new Map(matches.map((match) => [`${match.toolName}\0${match.trigger}\0${match.source}`, match])).values(),
+    ),
+  };
 }


### PR DESCRIPTION
## Summary
- replace in-memory deliberate tool retention with a scan over the configured number of recent channel messages
- reuse deliberate tool trigger detection, including custom trigger phrases, for retained tool exposure
- remove successful-tool retention bookkeeping from tool execution

## Test
- bun run check
- bunx biome check --write src/utils/tools/deliberateToolMode.ts src/utils/chat/contextPipeline.ts src/utils/chat/toolLoop.ts