### PR TITLE
Feat | Document Remove Dropdown Now Shows Chunk Preview

### DIFF
--- a/src/commands/memory/document/remove.ts
+++ b/src/commands/memory/document/remove.ts
@@ -215,6 +215,7 @@ export async function execute(
       const documentOptions: SelectOption[] = documents.map((doc) => ({
         label: safeSelectOptionText(doc.document_name),
         value: doc.document_id.toString(),
+        description: doc.first_chunk ? safeSelectOptionText(doc.first_chunk) : undefined,
       }));
 
       const modalResult = await promptWithPaginatedModal(selectionInteraction, locale, {

--- a/src/utils/db/repositories/ServerMemoryRepository.ts
+++ b/src/utils/db/repositories/ServerMemoryRepository.ts
@@ -502,22 +502,28 @@ export class ServerMemoryRepository implements IRepository<ServerMemoryExportSha
   async loadDocuments(
     serverId: number,
     personaId: number | null,
-  ): Promise<Array<{ document_id: number; document_name: string }>> {
+  ): Promise<Array<{ document_id: number; document_name: string; first_chunk: string | null }>> {
     if (personaId === null) {
-      return await sql<Array<{ document_id: number; document_name: string }>>`
-        SELECT document_id, document_name
-        FROM documents
-        WHERE server_id = ${serverId}
-          AND persona_id IS NULL
-        ORDER BY created_at DESC
+      return await sql<Array<{ document_id: number; document_name: string; first_chunk: string | null }>>`
+        SELECT d.document_id, d.document_name, dc.content AS first_chunk
+        FROM documents d
+        LEFT JOIN document_chunks dc
+          ON dc.document_id = d.document_id
+          AND dc.chunk_index = 0
+        WHERE d.server_id = ${serverId}
+          AND d.persona_id IS NULL
+        ORDER BY d.created_at DESC
       `;
     }
-    return await sql<Array<{ document_id: number; document_name: string }>>`
-      SELECT document_id, document_name
-      FROM documents
-      WHERE server_id = ${serverId}
-        AND persona_id = ${personaId}
-      ORDER BY created_at DESC
+    return await sql<Array<{ document_id: number; document_name: string; first_chunk: string | null }>>`
+      SELECT d.document_id, d.document_name, dc.content AS first_chunk
+      FROM documents d
+      LEFT JOIN document_chunks dc
+        ON dc.document_id = d.document_id
+        AND dc.chunk_index = 0
+      WHERE d.server_id = ${serverId}
+        AND d.persona_id = ${personaId}
+      ORDER BY d.created_at DESC
     `;
   }
 


### PR DESCRIPTION
## Summary
Add first-chunk content as the description field in the document removal dropdown, matching the UX of server/personal memory removes. Consistency with other memory removal dialogues, utility for memory maintenance

## Type(s)
- [ ] Bug Fix
- [X] Feature
- [ ] Refactor / Chore

## Quality Gates
- [X] `bun run vl` output shows no critical failures
- [X] (If adding or modifying a Discord Command) Followed command patterns and conventions in [`docs/subsystems/command-system.md`](../docs/subsystems/command-system.md) 
- [X] No hardcoded operational limits/timeouts (use env vars, document in `.env.optional.example`)

## Testing
Tested presentation of text and PDF document content preview in "/memory document remove", tested that document removal still works.

## Reviewer Notes
