### PR TITLE
Add optional ComfyUI model unload

### DIFF
--- a/.env.optional.example
+++ b/.env.optional.example
@@ -417,7 +417,9 @@ IMAGE_REFERENCE_MAX_TOTAL_BYTES=6291456
 IMAGE_REFERENCE_TINY_MAX_BYTES=950000
 # Per-reference byte budget before downscaling (default: 2097152 = 2 MiB)
 IMAGE_REFERENCE_MAX_SINGLE_BYTES=2097152
-# ComfyUI image runtime knobs. Most workflow details live in the workflow JSON.
+# ComfyUI image/video runtime knobs. Most workflow details live in the workflow JSON.
+# When true, unload ComfyUI models after a successful image or video generation (default: false).
+COMFYUI_UNLOAD_MODELS_AFTER_SUCCESS=false
 COMFYUI_REFERENCE_DENOISE=0.75
 COMFYUI_IMG2IMG_DENOISE=0.75
 COMFYUI_LANPAINT_STEPS=16

--- a/src/providers/custom/customComfyUiEndpoint.ts
+++ b/src/providers/custom/customComfyUiEndpoint.ts
@@ -177,6 +177,62 @@ function toUpperSnakeCase(value: string): string {
     .replace(/^_+|_+$/g, "");
 }
 
+function readOptionalBooleanEnv(name: string): boolean | null {
+  const rawValue = process.env[name];
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return null;
+  }
+
+  const normalized = rawValue.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "n", "off"].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
+
+function shouldUnloadComfyUiModelsAfterSuccessfulGeneration(): boolean {
+  return (
+    readOptionalBooleanEnv("COMFYUI_UNLOAD_MODELS_AFTER_SUCCESS") ??
+    readOptionalBooleanEnv("TOMORI_COMFYUI_UNLOAD_MODELS_AFTER_SUCCESS") ??
+    false
+  );
+}
+
+async function unloadComfyUiModelsAfterSuccessfulGeneration(
+  endpoint: CustomEndpointRow,
+  apiKey: string,
+  mode: ComfyUiGenerationMode,
+): Promise<void> {
+  if (!shouldUnloadComfyUiModelsAfterSuccessfulGeneration()) {
+    return;
+  }
+
+  try {
+    const response = await fetchUserRemoteUrl(`${endpoint.endpoint_url.replace(/\/+$/, "")}/free`, {
+      method: "POST",
+      headers: buildCustomHeaders(apiKey),
+      body: JSON.stringify({
+        unload_models: true,
+        free_memory: true,
+      }),
+    });
+
+    if (!response.ok) {
+      log.warn(
+        `ComfyUI model unload after successful ${mode} generation failed: ${response.status} ${response.statusText}`,
+      );
+      return;
+    }
+
+    log.info(`ComfyUI models unloaded after successful ${mode} generation.`);
+  } catch (error) {
+    log.warn(`ComfyUI model unload after successful ${mode} generation failed`, error);
+  }
+}
+
 function resolveComfyUiRuntimeWorkflowPath(endpoint: CustomEndpointRow): string | null {
   const extraConfigPath =
     isRecord(endpoint.extra_config) && typeof endpoint.extra_config.workflow_path === "string"
@@ -2674,6 +2730,7 @@ export async function generateComfyUiImageViaEndpoint(params: {
       };
     }),
   );
+  await unloadComfyUiModelsAfterSuccessfulGeneration(endpoint, apiKey, "image");
   return {
     imageData: imageBuffer.toString("base64"),
     mimeType: "image/png",
@@ -2704,6 +2761,7 @@ export async function generateComfyUiVideoViaEndpoint(params: {
   });
   const firstFile = files[0];
   const videoBuffer = await downloadComfyUiAsset(endpoint, apiKey, firstFile);
+  await unloadComfyUiModelsAfterSuccessfulGeneration(endpoint, apiKey, "video");
   return {
     videoData: videoBuffer,
     mimeType: "video/mp4",


### PR DESCRIPTION
## Summary
- add a false-by-default ComfyUI env flag to unload models after successful image/video generation
- call ComfyUI /free only after final generated media has been downloaded
- document the setting in .env.optional.example

## Verification
- bun run check