### PR TITLE
Fix /impersonate user generation error embeds

### DIFF
--- a/docs/en/architecture/pipelines/chat/02-evaluate-admission.md
+++ b/docs/en/architecture/pipelines/chat/02-evaluate-admission.md
@@ -39,6 +39,11 @@ non-runnable dispositions.
     bot-reply-block, full-privacy user
   - `"error"` — unexpected failure (rare)
 
+An accepted same-user conversational follow-up and a message queued behind a
+busy channel both use `"queued"`. Manual slash-command work, including user
+impersonation, skips follow-up replacement and enters the normal FIFO queue so
+the command payload remains intact.
+
 ## Side effects
 
 - **Voice transcription** — if the message has audio attachments, transcribes
@@ -140,7 +145,7 @@ Extensibility lives in the helpers it calls:
 |---|---|---|---|
 | `isMatrixRelayMessage`, `isRealUserLikeMessage` | `triggerProcessor.ts` | Trigger-source classification | A new bridge plugin would extend trigger detection here |
 | `transcribeMessageAudioAttachment` | `audioAttachmentTranscription.ts` | STT dispatch | STT providers register via `customEndpointService` — existing mechanism, not chat-specific |
-| `evaluateAdmissionQueueAndTriggerGate` | `admissionQueue.ts` | Channel-busy + trigger gate decision tree; includes cross-persona trigger guard that bypasses the follow-up path when the incoming message explicitly targets a different persona than the active one | → plugin plan candidate if plugins want to add admission policies |
+| `evaluateAdmissionQueueAndTriggerGate` | `admissionQueue.ts` | Channel-busy + trigger gate decision tree; includes cross-persona and manual-command guards that bypass follow-up replacement when the incoming message explicitly targets a different persona or represents command-owned work | → plugin plan candidate if plugins want to add admission policies |
 | `getSelfReplyChainOriginUser`, `updateSelfReplyChainState` | `selfReplyState.ts` | Self-reply chain memory | Internal — tightly coupled to cascade-trigger limit semantics |
 
 **The stage itself is internal** — there is no current seam for "replace

--- a/docs/en/architecture/pipelines/chat/03-handle-disposition.md
+++ b/docs/en/architecture/pipelines/chat/03-handle-disposition.md
@@ -8,14 +8,17 @@ Terminal handler for non-run dispositions.
 
 ## Mission
 
-The "exit door" for the four non-runnable dispositions. Currently log-only —
+The "exit door" for the four non-runnable dispositions. Currently log-only:
 emits `log.warn` for errors and `log.info` for ignore/queued/blocked. Exists as
 a named stage (rather than being inlined into the coordinator) precisely so
 disposition handling has a single seam to grow into.
 
 Separately, the coordinator (`tomoriChat`) returns the final
 `ChatAdmissionDisposition` to its caller (`"run"` after a successful turn,
-otherwise the disposition reported by stage 02). Callers that schedule work
+otherwise the disposition reported by stage 02). A `"queued"` return means the
+message was accepted into live channel work, not discarded. The coordinator
+leaves queue callbacks attached, and the replayed invocation reports the
+eventual generation outcome. Callers that schedule work
 externally — notably the reminder processor (`src/timers/reminderProcessor.ts`)
 — inspect this return value to decide whether to delete the source DB row,
 treat it as in-flight (queued), or leave it for the next reconcile cycle
@@ -52,8 +55,10 @@ retry budget across restarts.
 
 After this stage runs:
 
-- The chat coordinator returns immediately; no lock is acquired, no further
-  stages execute for this message.
+- For `"ignore"`, `"blocked"`, and `"error"`, the chat coordinator returns
+  immediately; no lock is acquired and no further stages execute for this
+  message. An accepted `"queued"` admission has already enqueued work and is
+  replayed by the channel-lock stage.
 - The original `messageCreate` event has been fully consumed.
 - Channel state (locks, queues, self-reply chain) is **not** mutated here —
   stage 02 made any required mutations already.

--- a/docs/en/architecture/pipelines/chat/04-channel-lock.md
+++ b/docs/en/architecture/pipelines/chat/04-channel-lock.md
@@ -87,6 +87,10 @@ The callback receives `LockedChatTurn`:
   otherwise the queued replay will be a silently-degraded copy of the original
   call.
 
+Manual slash-command work bypasses the latest-follow-up replacement path and is
+stored in this FIFO queue. This preserves command-owned callbacks and payload
+fields such as the user-impersonation target while an ordinary turn is active.
+
 **`skipLock=true` path:**
 
 - Re-entries from retry/post-turn effects pass `skipLock=true`. The stage

--- a/src/events/messageCreate/tomoriChat.ts
+++ b/src/events/messageCreate/tomoriChat.ts
@@ -10,6 +10,7 @@ import {
 import { buildChatTurnContext } from "@/utils/chat/contextPipeline";
 import { runGenerationTurn } from "@/utils/chat/generationTurn";
 import type { ChatAdmissionDisposition, ChatIncoming, TomoriChatInput } from "@/utils/chat/types";
+import { installUserImpersonationCompletion } from "@/utils/chat/userImpersonationCompletion";
 import { enrichErrorContext, runWithErrorContext } from "@/utils/misc/errorContextStore";
 import { runPostTurnEffects, shouldRetryEmptyResponse } from "@/utils/chat/postTurnEffects";
 import { createChatResponseSink, handleStopResponse } from "@/utils/chat/responseEmitter";
@@ -33,8 +34,9 @@ export {
  */
 export async function tomoriChat(input: TomoriChatInput): Promise<ChatAdmissionDisposition> {
   const incoming = normalizeChatInvocation(input);
+  const userImpersonationCompletion = installUserImpersonationCompletion(incoming);
 
-  return runWithErrorContext(
+  const disposition = await runWithErrorContext(
     {
       source: "chat",
       userDiscId: incoming.message.author.id,
@@ -43,6 +45,15 @@ export async function tomoriChat(input: TomoriChatInput): Promise<ChatAdmissionD
     },
     () => runAdmittedChatTurn(incoming),
   );
+
+  // User impersonation owns its user-facing error UI at the slash interaction. Waiting here keeps
+  // returned error/timeout statuses and queued turns attached to that interaction instead of letting
+  // a non-throwing tomoriChat() result be mistaken for successful generation.
+  if (userImpersonationCompletion) {
+    await userImpersonationCompletion;
+  }
+
+  return disposition;
 }
 
 async function runAdmittedChatTurn(incoming: ChatIncoming): Promise<ChatAdmissionDisposition> {
@@ -50,7 +61,12 @@ async function runAdmittedChatTurn(incoming: ChatIncoming): Promise<ChatAdmissio
 
   if (admission.disposition !== "run") {
     await handleChatDisposition(admission);
-    await incoming.onQueueDiscard?.("admission_rejected");
+    // A queued turn is still live work: its callbacks are copied into QueuedMessage and fire when
+    // that turn eventually runs (or is genuinely discarded). Treating "queued" as a discard here
+    // detaches command callers from the real generation outcome.
+    if (admission.disposition !== "queued") {
+      await incoming.onQueueDiscard?.("admission_rejected");
+    }
     return admission.disposition;
   }
 

--- a/src/locales/en-US/commands/impersonate.ts
+++ b/src/locales/en-US/commands/impersonate.ts
@@ -16,6 +16,7 @@ export default {
     user_impersonation_notice_footer: `{user} triggered a {target} impersonation`,
     me_success_title: `User Impersonation Triggered`,
     me_success_description: `Generated message as {user}.`,
+    user_generation_skipped_description: `User impersonation did not generate a message. Check the server's access, persona, quota, and provider settings, then try again.`,
     no_messages_title: `No Messages Found`,
     no_messages_description: `No messages found in this channel. Send at least one message before using user impersonation.`,
     cooldown_active_user: `This server's managers have configured a cooldown. Please wait **{seconds}** seconds before using \`/impersonate user\` again. This cooldown is shared with message triggers and \`/respond\`.`,

--- a/src/locales/ja/commands/impersonate.ts
+++ b/src/locales/ja/commands/impersonate.ts
@@ -9,6 +9,7 @@ export default {
     user_impersonation_notice_footer: `{user}が{target}のなりすましをトリガーしました`,
     me_success_title: `ユーザーなりすましが発動しました`,
     me_success_description: `{user}としてメッセージを生成できました.`,
+    user_generation_skipped_description: `ユーザーなりすましのメッセージを生成できませんでした。サーバーのアクセス権、ペルソナ、クォータ、プロバイダー設定を確認して、もう一度お試しください。`,
     no_messages_title: `メッセージが見つかりません`,
     no_messages_description: `このチャンネルにメッセージが見つかりません。ユーザーなりすましを使用する前に、少なくとも1つのメッセージを送信してください。`,
     cooldown_active_user: `このサーバーの管理者がクールダウンを設定しています。\`/impersonate user\` を再度使用するまで、あと **{seconds}** 秒お待ちください。このクールダウンはメッセージトリガーと\`/respond\`と共有されています。`,

--- a/src/utils/chat/admissionQueue.ts
+++ b/src/utils/chat/admissionQueue.ts
@@ -125,6 +125,7 @@ async function evaluateLockedChannelAdmission(args: {
   if (
     !incoming.isStopResponse &&
     !incoming.isPersonaJob &&
+    !incoming.isManuallyTriggered &&
     !hasCrossPersonaTrigger &&
     queueFollowUpForLockedTurn({
       lockEntry,
@@ -137,11 +138,18 @@ async function evaluateLockedChannelAdmission(args: {
       manualStreamingContextOverrides: followUpOverrides,
       isNaturalStopMessage: args.isNaturalStopMessage,
       shouldSurfaceUserErrors: true,
+      isUserImpersonation: incoming.isUserImpersonation,
+      impersonatedUserId: incoming.impersonatedUserId,
       onGenerationResult: incoming.onGenerationResult,
       onQueueDiscard: incoming.onQueueDiscard,
     })
   ) {
-    return ignored("locked_follow_up_queued");
+    return {
+      incoming,
+      disposition: "queued",
+      locale: "en-US",
+      reason: "locked_follow_up_queued",
+    };
   }
 
   if (!earlyTomoriState) {

--- a/src/utils/chat/channelQueue.ts
+++ b/src/utils/chat/channelQueue.ts
@@ -448,6 +448,8 @@ export function queueFollowUpForLockedTurn(args: {
   manualStreamingContextOverrides: QueuedMessage["manualStreamingContextOverrides"];
   isNaturalStopMessage: boolean;
   shouldSurfaceUserErrors?: boolean;
+  isUserImpersonation?: boolean;
+  impersonatedUserId?: string;
   onGenerationResult?: ChatGenerationResultHandler;
   onQueueDiscard?: QueuedMessageDiscardHandler;
 }): boolean {
@@ -472,8 +474,8 @@ export function queueFollowUpForLockedTurn(args: {
       isFollowUp: true,
       selectedPersonaId: args.lockEntry.activePersonaId,
       triggeredPersonaIds: args.lockEntry.activeTriggeredPersonaIds,
-      isUserImpersonation: args.lockEntry.activeIsUserImpersonation,
-      impersonatedUserId: args.lockEntry.activeImpersonatedUserId,
+      isUserImpersonation: args.isUserImpersonation,
+      impersonatedUserId: args.impersonatedUserId,
       textQuotaSource: args.textQuotaSource,
       textQuotaTriggerKey: args.textQuotaTriggerKey,
       textQuotaUserDiscId: args.textQuotaUserDiscId,
@@ -499,8 +501,8 @@ export function queueFollowUpForLockedTurn(args: {
     isFollowUp: true,
     selectedPersonaId: args.lockEntry.activePersonaId,
     triggeredPersonaIds: args.lockEntry.activeTriggeredPersonaIds,
-    isUserImpersonation: args.lockEntry.activeIsUserImpersonation,
-    impersonatedUserId: args.lockEntry.activeImpersonatedUserId,
+    isUserImpersonation: args.isUserImpersonation,
+    impersonatedUserId: args.impersonatedUserId,
     textQuotaSource: args.textQuotaSource,
     textQuotaTriggerKey: args.textQuotaTriggerKey,
     textQuotaUserDiscId: args.textQuotaUserDiscId,

--- a/src/utils/chat/userImpersonationCompletion.ts
+++ b/src/utils/chat/userImpersonationCompletion.ts
@@ -1,0 +1,101 @@
+import type { ChatIncoming, GenerationTurnResult, QueuedMessageDiscardReason } from "@/utils/chat/types";
+
+function normalizeError(value: unknown, fallbackMessage: string): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null && "message" in value) {
+    const message = (value as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      return new Error(message);
+    }
+  }
+
+  return new Error(fallbackMessage);
+}
+
+export function getUserImpersonationGenerationError(result: GenerationTurnResult): Error | null {
+  if (result.status !== "error" && result.status !== "timeout") {
+    return null;
+  }
+
+  const fallbackMessage =
+    result.status === "timeout" ? "User impersonation generation timed out." : "User impersonation generation failed.";
+
+  for (let index = result.streamResults.length - 1; index >= 0; index--) {
+    const streamResult = result.streamResults[index];
+    if (streamResult && (streamResult.status === "error" || streamResult.status === "timeout")) {
+      return normalizeError(streamResult.data, fallbackMessage);
+    }
+  }
+
+  return new Error(fallbackMessage);
+}
+
+/**
+ * Makes user-impersonation chat calls wait for the real generation outcome, including turns that
+ * are queued behind an active channel lock. The slash-command caller can then use its existing
+ * try/catch to edit the deferred interaction into an ephemeral error embed instead of reporting
+ * success merely because tomoriChat() returned a non-throwing status.
+ */
+export function installUserImpersonationCompletion(incoming: ChatIncoming): Promise<void> | null {
+  if (!incoming.isUserImpersonation) {
+    return null;
+  }
+
+  const previousGenerationHandler = incoming.onGenerationResult;
+  const previousDiscardHandler = incoming.onQueueDiscard;
+
+  let settled = false;
+  let resolveCompletion!: () => void;
+  let rejectCompletion!: (error: Error) => void;
+  const completion = new Promise<void>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+
+  const resolveOnce = () => {
+    if (settled) return;
+    settled = true;
+    resolveCompletion();
+  };
+  const rejectOnce = (error: unknown, fallbackMessage: string) => {
+    if (settled) return;
+    settled = true;
+    rejectCompletion(normalizeError(error, fallbackMessage));
+  };
+
+  incoming.onGenerationResult = async (result) => {
+    try {
+      await previousGenerationHandler?.(result);
+    } catch (error) {
+      rejectOnce(error, "User impersonation generation result handler failed.");
+      return;
+    }
+
+    const generationError = getUserImpersonationGenerationError(result);
+    if (generationError) {
+      rejectOnce(generationError, generationError.message);
+      return;
+    }
+
+    resolveOnce();
+  };
+
+  incoming.onQueueDiscard = async (reason: QueuedMessageDiscardReason) => {
+    try {
+      await previousDiscardHandler?.(reason);
+    } catch (error) {
+      rejectOnce(error, "User impersonation queue discard handler failed.");
+      return;
+    }
+
+    rejectOnce(
+      new Error(`User impersonation generation was discarded before completion (${reason}).`),
+      "User impersonation generation was discarded before completion.",
+    );
+  };
+
+  return completion;
+}

--- a/src/utils/chat/userImpersonationCompletion.ts
+++ b/src/utils/chat/userImpersonationCompletion.ts
@@ -1,5 +1,14 @@
 import type { ChatIncoming, GenerationTurnResult, QueuedMessageDiscardReason } from "@/utils/chat/types";
 
+export class UserImpersonationGenerationSkippedError extends Error {
+  readonly reason = "skipped" as const;
+
+  constructor() {
+    super("User impersonation did not generate a message.");
+    this.name = "UserImpersonationGenerationSkippedError";
+  }
+}
+
 function normalizeError(value: unknown, fallbackMessage: string): Error {
   if (value instanceof Error) {
     return value;
@@ -16,6 +25,10 @@ function normalizeError(value: unknown, fallbackMessage: string): Error {
 }
 
 export function getUserImpersonationGenerationError(result: GenerationTurnResult): Error | null {
+  if (result.status === "skipped") {
+    return new UserImpersonationGenerationSkippedError();
+  }
+
   if (result.status !== "error" && result.status !== "timeout") {
     return null;
   }

--- a/src/utils/impersonate/impersonateOperations.ts
+++ b/src/utils/impersonate/impersonateOperations.ts
@@ -32,6 +32,7 @@ import { getCachedWhitelistStatus } from "@/utils/cache/channelWhitelistCache";
 import { getCachedUserRow } from "@/utils/cache/userCache";
 import { getCachedPersonalSpotlightStatus } from "@/utils/cache/personalSpotlightCache";
 import { filterPersonasForTrigger, isPersonaAllowedForTrigger } from "@/utils/persona/personaAccess";
+import { UserImpersonationGenerationSkippedError } from "@/utils/chat/userImpersonationCompletion";
 
 type ImpersonationInteraction = ChatInputCommandInteraction;
 
@@ -490,11 +491,14 @@ export async function executeUserImpersonation(
 
     if (interaction.deferred || interaction.replied) {
       const isTimeoutError = error instanceof Error && /timed?\s*out|timeout/i.test(error.message);
+      const isSkippedError = error instanceof UserImpersonationGenerationSkippedError;
       const description = isTimeoutError
         ? localizer(locale, "genai.error_stream_timeout_description")
-        : localizer(locale, "genai.generic_error_description", {
-            error_message: error instanceof Error ? error.message : "Unknown error",
-          });
+        : isSkippedError
+          ? localizer(locale, "commands.impersonate.user_generation_skipped_description")
+          : localizer(locale, "genai.generic_error_description", {
+              error_message: error instanceof Error ? error.message : "Unknown error",
+            });
       await interaction.editReply({
         embeds: [
           new EmbedBuilder()

--- a/tests/regression/chat/chat.regression.test.ts
+++ b/tests/regression/chat/chat.regression.test.ts
@@ -568,6 +568,171 @@ describe("chat regression harness", () => {
     expect(processedMessageIds).toEqual([queuedMessage.id]);
   });
 
+  it("queues a manual user impersonation in FIFO and replays its incoming target", async () => {
+    const client = makeClient();
+    const fixture = conversations[0];
+    const activeMessage = makeMessage(fixture, client);
+    const queuedMessage = makeMessage(
+      {
+        ...fixture,
+        id: "queued_user_impersonation",
+        message: {
+          ...fixture.message,
+          authorBot: true,
+          content: "latest channel message",
+        },
+      },
+      client,
+    );
+    const targetUserId = "target_user_001";
+    const tomoriState = makeTomoriState(fixture, {
+      id: 1001,
+      nickname: "Tomori",
+      isAlter: false,
+      triggers: ["tomori"],
+    });
+    const incoming: ChatIncoming = {
+      client,
+      message: queuedMessage,
+      isFromQueue: false,
+      isManuallyTriggered: true,
+      retryCount: 0,
+      skipLock: false,
+      isPersonaJob: false,
+      isUserImpersonation: true,
+      impersonatedUserId: targetUserId,
+      textQuotaSource: "user",
+      manualTriggerInvoker: {
+        userDiscId: activeMessage.author.id,
+        username: "Sparrow",
+      },
+    };
+    const lockEntry = getOrCreateChannelLockEntry(channelId, guildId);
+    acquireChannelLockForTurn(lockEntry, {
+      messageId: activeMessage.id,
+      userDiscId: activeMessage.author.id,
+      isPersonaJob: false,
+      isCommandTriggered: false,
+    });
+    setActiveChannelTurnState(lockEntry, {
+      activePersonaId: tomoriState.persona_id,
+      triggeredPersonaIds: [tomoriState.persona_id],
+      followUpEligible: true,
+      isUserImpersonation: false,
+    });
+
+    const disposition = await evaluateAdmissionQueueAndTriggerGate({
+      incoming,
+      channelScope: {
+        guild: null,
+        serverDiscId: guildId,
+        isDMChannel: false,
+      },
+      earlyTomoriState: tomoriState,
+      earlyAllPersonas: [tomoriState],
+      userDiscId: activeMessage.author.id,
+      cooldownUserDiscId: activeMessage.author.id,
+      isActiveNaturalStopMessage: false,
+      isNaturalStopMessage: false,
+    });
+
+    expect(disposition?.disposition).toBe("queued");
+    expect(disposition?.reason).toBe("locked_busy_queued");
+    expect(lockEntry.messageQueue).toHaveLength(1);
+    expect(lockEntry.messageQueue[0]).toMatchObject({
+      isUserImpersonation: true,
+      impersonatedUserId: targetUserId,
+      isManuallyTriggered: true,
+    });
+
+    const replayedTargets: string[] = [];
+    releaseChannelLockAndReplayQueue({
+      channelId,
+      lockEntry,
+      completedMessageId: activeMessage.id,
+      handleStopResponse: async () => {},
+      processQueuedMessage: async (queued) => {
+        if (queued.isUserImpersonation && queued.impersonatedUserId) {
+          replayedTargets.push(queued.impersonatedUserId);
+        }
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(replayedTargets).toEqual([targetUserId]);
+  });
+
+  it("reports accepted live follow-ups as queued and keeps incoming impersonation metadata", async () => {
+    const client = makeClient();
+    const fixture = conversations[0];
+    const activeMessage = makeMessage(fixture, client);
+    const followUpMessage = makeMessage(
+      {
+        ...fixture,
+        id: "eligible_follow_up_impersonation",
+        message: {
+          ...fixture.message,
+          content: "Tomori, continue",
+        },
+      },
+      client,
+    );
+    const targetUserId = "follow_up_target_001";
+    const tomoriState = makeTomoriState(fixture, {
+      id: 1001,
+      nickname: "Tomori",
+      isAlter: false,
+      triggers: ["tomori"],
+    });
+    const incoming: ChatIncoming = {
+      client,
+      message: followUpMessage,
+      isFromQueue: false,
+      retryCount: 0,
+      skipLock: false,
+      isPersonaJob: false,
+      isUserImpersonation: true,
+      impersonatedUserId: targetUserId,
+      textQuotaSource: "user",
+    };
+    const lockEntry = getOrCreateChannelLockEntry(channelId, guildId);
+    acquireChannelLockForTurn(lockEntry, {
+      messageId: activeMessage.id,
+      userDiscId: activeMessage.author.id,
+      isPersonaJob: false,
+      isCommandTriggered: false,
+    });
+    setActiveChannelTurnState(lockEntry, {
+      activePersonaId: tomoriState.persona_id,
+      triggeredPersonaIds: [tomoriState.persona_id],
+      followUpEligible: true,
+      isUserImpersonation: false,
+    });
+
+    const disposition = await evaluateAdmissionQueueAndTriggerGate({
+      incoming,
+      channelScope: {
+        guild: null,
+        serverDiscId: guildId,
+        isDMChannel: false,
+      },
+      earlyTomoriState: tomoriState,
+      earlyAllPersonas: [tomoriState],
+      userDiscId: activeMessage.author.id,
+      cooldownUserDiscId: activeMessage.author.id,
+      isActiveNaturalStopMessage: false,
+      isNaturalStopMessage: false,
+    });
+
+    expect(disposition?.disposition).toBe("queued");
+    expect(disposition?.reason).toBe("locked_follow_up_queued");
+    expect(lockEntry.messageQueue[0]).toMatchObject({
+      isFollowUp: true,
+      isUserImpersonation: true,
+      impersonatedUserId: targetUserId,
+    });
+  });
+
   it("notifies queued message discard handlers when the channel queue is cleared", async () => {
     const client = makeClient();
     const fixture = conversations[0];

--- a/tests/unit/chat/userImpersonationCompletion.test.ts
+++ b/tests/unit/chat/userImpersonationCompletion.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import type { ChatIncoming, GenerationTurnResult } from "@/utils/chat/types";
+import {
+  getUserImpersonationGenerationError,
+  installUserImpersonationCompletion,
+} from "@/utils/chat/userImpersonationCompletion";
+
+function makeIncoming(overrides: Partial<ChatIncoming> = {}): ChatIncoming {
+  return {
+    isUserImpersonation: true,
+    ...overrides,
+  } as ChatIncoming;
+}
+
+function makeResult(
+  status: GenerationTurnResult["status"],
+  streamResults: GenerationTurnResult["streamResults"] = [],
+): GenerationTurnResult {
+  return {
+    status,
+    streamResults,
+    personaResponses: [],
+  };
+}
+
+describe("user impersonation generation completion", () => {
+  it("does not install completion tracking for normal chat turns", () => {
+    const incoming = makeIncoming({ isUserImpersonation: false });
+    expect(installUserImpersonationCompletion(incoming)).toBeNull();
+  });
+
+  it("resolves only after a completed generation result", async () => {
+    const incoming = makeIncoming();
+    const completion = installUserImpersonationCompletion(incoming);
+    expect(completion).not.toBeNull();
+
+    await incoming.onGenerationResult?.(makeResult("completed"));
+    await expect(completion!).resolves.toBeUndefined();
+  });
+
+  it("turns normalized provider errors into rejected completion errors", async () => {
+    const result = makeResult("error", [
+      {
+        status: "error",
+        data: {
+          type: "api_error",
+          message: "provider exploded",
+          retryable: false,
+        },
+      },
+    ]);
+    expect(getUserImpersonationGenerationError(result)?.message).toBe("provider exploded");
+
+    const incoming = makeIncoming();
+    const completion = installUserImpersonationCompletion(incoming)!;
+    const caught = completion.catch((error: unknown) => error);
+    await incoming.onGenerationResult?.(result);
+
+    expect(await caught).toBeInstanceOf(Error);
+    expect((await caught as Error).message).toBe("provider exploded");
+  });
+
+  it("rejects timeout results so the slash command can show its timeout embed", async () => {
+    const incoming = makeIncoming();
+    const completion = installUserImpersonationCompletion(incoming)!;
+    const caught = completion.catch((error: unknown) => error);
+    await incoming.onGenerationResult?.(
+      makeResult("timeout", [{ status: "timeout", data: new Error("Stream timed out due to inactivity.") }]),
+    );
+
+    expect((await caught as Error).message).toBe("Stream timed out due to inactivity.");
+  });
+
+  it("rejects when a queued impersonation is discarded before generation", async () => {
+    const incoming = makeIncoming();
+    const completion = installUserImpersonationCompletion(incoming)!;
+    const caught = completion.catch((error: unknown) => error);
+    await incoming.onQueueDiscard?.("stale_lock_release");
+
+    expect((await caught as Error).message).toContain("stale_lock_release");
+  });
+
+  it("preserves pre-existing generation and discard callbacks", async () => {
+    const seen: string[] = [];
+    const incoming = makeIncoming({
+      onGenerationResult: async () => {
+        seen.push("generation");
+      },
+      onQueueDiscard: async () => {
+        seen.push("discard");
+      },
+    });
+
+    const completion = installUserImpersonationCompletion(incoming)!;
+    await incoming.onGenerationResult?.(makeResult("completed"));
+    await completion;
+    expect(seen).toEqual(["generation"]);
+
+    const discardedIncoming = makeIncoming({
+      onQueueDiscard: async () => {
+        seen.push("discard");
+      },
+    });
+    const discardedCompletion = installUserImpersonationCompletion(discardedIncoming)!;
+    const caught = discardedCompletion.catch((error: unknown) => error);
+    await discardedIncoming.onQueueDiscard?.("channel_queue_cleared");
+    await caught;
+
+    expect(seen).toEqual(["generation", "discard"]);
+  });
+});

--- a/tests/unit/chat/userImpersonationCompletion.test.ts
+++ b/tests/unit/chat/userImpersonationCompletion.test.ts
@@ -57,7 +57,7 @@ describe("user impersonation generation completion", () => {
     await incoming.onGenerationResult?.(result);
 
     expect(await caught).toBeInstanceOf(Error);
-    expect((await caught as Error).message).toBe("provider exploded");
+    expect(((await caught) as Error).message).toBe("provider exploded");
   });
 
   it("rejects timeout results so the slash command can show its timeout embed", async () => {
@@ -68,7 +68,20 @@ describe("user impersonation generation completion", () => {
       makeResult("timeout", [{ status: "timeout", data: new Error("Stream timed out due to inactivity.") }]),
     );
 
-    expect((await caught as Error).message).toBe("Stream timed out due to inactivity.");
+    expect(((await caught) as Error).message).toBe("Stream timed out due to inactivity.");
+  });
+
+  it("rejects skipped results instead of treating a guarded turn as success", async () => {
+    expect(getUserImpersonationGenerationError(makeResult("skipped"))?.message).toBe(
+      "User impersonation did not generate a message.",
+    );
+
+    const incoming = makeIncoming();
+    const completion = installUserImpersonationCompletion(incoming)!;
+    const caught = completion.catch((error: unknown) => error);
+    await incoming.onGenerationResult?.(makeResult("skipped"));
+
+    expect(((await caught) as Error).message).toBe("User impersonation did not generate a message.");
   });
 
   it("rejects when a queued impersonation is discarded before generation", async () => {
@@ -77,7 +90,7 @@ describe("user impersonation generation completion", () => {
     const caught = completion.catch((error: unknown) => error);
     await incoming.onQueueDiscard?.("stale_lock_release");
 
-    expect((await caught as Error).message).toContain("stale_lock_release");
+    expect(((await caught) as Error).message).toContain("stale_lock_release");
   });
 
   it("preserves pre-existing generation and discard callbacks", async () => {


### PR DESCRIPTION
## Summary

Fixes `/impersonate user` reporting success or staying silent when generation actually fails.

### What changed

- Track the real generation completion for user impersonation turns.
- Propagate returned `error` and `timeout` generation results back to the slash command so its existing catch path edits the deferred interaction into the appropriate ephemeral error embed.
- Preserve completion tracking when the turn is queued behind an active channel lock.
- Do not treat the `queued` admission disposition as an immediate queue discard.
- Reject completion if queued impersonation work is genuinely discarded before generation.
- Preserve any pre-existing `onGenerationResult` / `onQueueDiscard` callbacks.

### Why

User impersonation intentionally suppresses channel-level stream/provider error embeds because the slash interaction owns the user-facing error UI. However, normalized provider errors and timeout statuses were returned as values rather than thrown, so `executeUserImpersonation()` could mistake a resolved `tomoriChat()` call for successful generation. Queued impersonation turns had the same issue because `tomoriChat()` returned `queued` before the real generation finished.

### Tests

Adds unit coverage for:

- successful completion
- normalized provider errors
- generation timeouts
- genuine queue discard
- preservation of existing completion/discard callbacks

Target branch: `refactor/command-modernization`.