### PR TITLE
Fix | Prevent Discord pin events from triggering persona replies

### DIFF
--- a/src/events/messageCreate/tomoriChat.ts
+++ b/src/events/messageCreate/tomoriChat.ts
@@ -1,4 +1,4 @@
-import type { Client, Message } from "discord.js";
+import { MessageType, type Client, type Message } from "discord.js";
 import { evaluateChatAdmission, handleChatDisposition, normalizeChatInvocation } from "@/utils/chat/admission";
 import {
   clearChannelProcessingQueue,
@@ -137,5 +137,12 @@ async function runAdmittedChatTurn(incoming: ChatIncoming): Promise<ChatAdmissio
 
 /** Thin event-dispatch adapter: satisfies EventFunction(client, ...args) called by the event loader. */
 export default async function messageCreateHandler(client: Client, message: Message): Promise<void> {
+  // Discord emits pin notifications as ChannelPinnedMessage system messages with
+  // a message reference to the pinned message. That reference is context metadata,
+  // not an intentional conversational reply, so it must never enter the trigger path.
+  if (message.type === MessageType.ChannelPinnedMessage) {
+    return;
+  }
+
   await tomoriChat({ client, message, isFromQueue: false });
 }


### PR DESCRIPTION
## Summary

Prevent Discord `ChannelPinnedMessage` system messages from entering TomoriBot's normal chat trigger pipeline.

Discord creates a pin notification as a `messageCreate` event and gives it a `message_reference` pointing to the pinned message. TomoriBot's reply detection interprets references to bot/persona messages as conversational replies, so pinning a persona message can accidentally trigger generation.

This PR filters `MessageType.ChannelPinnedMessage` in the thin Discord `messageCreate` adapter before calling `tomoriChat()`.

## Why

A pin notification is channel activity, not intentional user input. Pinning a persona message should not cause the persona to immediately reply.

Pin activity can still be loaded from Discord history as context. That behavior is handled independently by the companion context PR.

## Scope

- Ignores only `MessageType.ChannelPinnedMessage` at the event entry point.
- Leaves normal user replies, mentions, trigger words, autochat, and manually invoked turns unchanged.
- Does not remove pin events from Discord history or context fetching.