### PR TITLE
Fix phantom welcomes for members who leave before greeting

### DIFF
--- a/src/events/guildMemberAdd/helpers/welcomeMembership.ts
+++ b/src/events/guildMemberAdd/helpers/welcomeMembership.ts
@@ -1,0 +1,24 @@
+import type { GuildMember } from "discord.js";
+
+/**
+ * Fetch the current guild membership from Discord and verify it is the same
+ * membership instance that originally triggered the welcome flow.
+ *
+ * A user can leave and rejoin with the same Discord user ID while a delayed
+ * welcome is still pending. Comparing joinedTimestamp prevents the old welcome
+ * from being delivered to the new membership instance.
+ *
+ * @param originalMember - Membership instance that started the welcome flow
+ * @returns Fresh member data when the original membership is still active
+ */
+export async function fetchCurrentWelcomeMember(originalMember: GuildMember): Promise<GuildMember | null> {
+  const currentMember = await originalMember.guild.members
+    .fetch({ user: originalMember.id, force: true })
+    .catch(() => null);
+
+  if (!currentMember || currentMember.joinedTimestamp !== originalMember.joinedTimestamp) {
+    return null;
+  }
+
+  return currentMember;
+}

--- a/src/events/guildMemberAdd/newUser.ts
+++ b/src/events/guildMemberAdd/newUser.ts
@@ -23,6 +23,7 @@ import {
   ZAI_GENERAL_CHAT_COMPLETIONS_URL,
 } from "@/providers/zai/zaiShared";
 import { resolveWelcomeDelayMs, waitForWelcomeDelay } from "@/events/guildMemberAdd/helpers/welcomeDelay";
+import { fetchCurrentWelcomeMember } from "@/events/guildMemberAdd/helpers/welcomeMembership";
 
 /**
  * Provider-to-chat-completions-URL mapping for vision model routing.
@@ -231,8 +232,7 @@ async function triggerWelcomeMessage(client: Client, member: GuildMember): Promi
     log.info(`Waiting ${welcomeDelayMs}ms before welcoming ${member.user.tag}`);
     await waitForWelcomeDelay(welcomeDelayMs);
 
-    const currentMember = member.guild.members.cache.get(member.id);
-    if (!currentMember || currentMember.joinedTimestamp !== member.joinedTimestamp) {
+    if (!(await fetchCurrentWelcomeMember(member))) {
       log.info(`Skipping welcome for ${member.user.tag}: original membership ended during the onboarding grace period`);
       return;
     }
@@ -307,6 +307,12 @@ async function triggerWelcomeMessage(client: Client, member: GuildMember): Promi
     avatarDescription,
   });
   const forcedMentions = await buildForcedMentionsForUser(member.id, client, member.guild);
+
+  if (!(await fetchCurrentWelcomeMember(member))) {
+    log.info(`Skipping welcome for ${member.user.tag}: original membership ended before welcome generation`);
+    return;
+  }
+
   const welcomeStartTime = Date.now();
 
   suppressNextSelfReply(welcomeChannel.id);

--- a/tests/unit/events/welcomeMembership.test.ts
+++ b/tests/unit/events/welcomeMembership.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { GuildMember } from "discord.js";
+import { fetchCurrentWelcomeMember } from "@/events/guildMemberAdd/helpers/welcomeMembership";
+
+function makeMember(params?: {
+  joinedTimestamp?: number | null;
+  fetchedMember?: GuildMember | null;
+  fetchRejects?: boolean;
+}) {
+  const fetch = mock(async () => {
+    if (params?.fetchRejects) throw new Error("Unknown Member");
+    return params?.fetchedMember ?? null;
+  });
+
+  const member = {
+    id: "123456789012345678",
+    joinedTimestamp: params?.joinedTimestamp ?? 1_000,
+    guild: {
+      members: { fetch },
+    },
+  } as unknown as GuildMember;
+
+  return { member, fetch };
+}
+
+describe("fetchCurrentWelcomeMember", () => {
+  it("force-fetches the member from Discord instead of trusting cache state", async () => {
+    const currentMember = {
+      id: "123456789012345678",
+      joinedTimestamp: 1_000,
+    } as GuildMember;
+    const { member, fetch } = makeMember({ fetchedMember: currentMember });
+
+    expect(await fetchCurrentWelcomeMember(member)).toBe(currentMember);
+    expect(fetch).toHaveBeenCalledWith({ user: member.id, force: true });
+  });
+
+  it("returns null when the member has left the guild", async () => {
+    const { member } = makeMember({ fetchRejects: true });
+
+    expect(await fetchCurrentWelcomeMember(member)).toBeNull();
+  });
+
+  it("returns null when the user left and rejoined before the old welcome completed", async () => {
+    const rejoinedMember = {
+      id: "123456789012345678",
+      joinedTimestamp: 2_000,
+    } as GuildMember;
+    const { member } = makeMember({ joinedTimestamp: 1_000, fetchedMember: rejoinedMember });
+
+    expect(await fetchCurrentWelcomeMember(member)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the delayed welcome flow so Tomori does not greet a member who has already left the server, or greet a rejoined membership using an older join event.

## What changed

- Force-fetch the member from Discord after the configured welcome delay instead of trusting `guild.members.cache`.
- Keep the original `joinedTimestamp` check so leave/rejoin cycles invalidate the stale welcome.
- Re-check the membership immediately before starting `tomoriChat()` to cover departures during channel/persona/avatar preparation.
- Add focused unit tests for active membership, departed membership, and leave/rejoin behavior.

## Why

The previous code checked `guild.members.cache` only once immediately after the delay. That cache can be stale around a `guildMemberRemove` event, and Tomori also sweeps guild members from its cache. In addition, a member could leave after that one check while the welcome flow was still doing asynchronous preparation.

The new helper uses `guild.members.fetch({ user, force: true })` as the authoritative membership check at both boundaries.

## Test coverage

`tests/unit/events/welcomeMembership.test.ts` is automatically discovered by the existing `**/*.test.ts` test runner and covers:

- fresh member lookup with `force: true`
- member no longer present
- same user ID leaving and rejoining with a different `joinedTimestamp`
