### PR TITLE
Add Fish Audio S2 Pro TTS support

### DIFF
--- a/.env.optional.example
+++ b/.env.optional.example
@@ -366,6 +366,35 @@ TTS_SYNTHESIZE_TIMEOUT_MS=240000
 #IRODORI_TTS_MODEL_ID=Aratako/Irodori-TTS-v4.1-Small
 # Local checkpoint file path for Irodori-TTS. Overrides IRODORI_TTS_MODEL_ID when set (default: unset).
 #IRODORI_TTS_CHECKPOINT=
+# Fish Audio S2 Pro local sidecar (optional)
+# Engine-specific wrapper port. Falls back to TOMORI_TTS_PORT when unset.
+#FISH_S2_PORT=8015
+# Fish wrapper bind address. Keep loopback unless remote access is intentional.
+#TOMORI_TTS_HOST=127.0.0.1
+# Optional bearer token. Use the same value as the custom endpoint API key in TomoriBot.
+#FISH_S2_API_KEY=
+# Shared bearer-token fallback for local TTS wrappers.
+#TOMORI_TTS_API_KEY=
+# Explicitly allow an unauthenticated non-loopback Fish bind. Keep disabled in normal deployments.
+#FISH_S2_ALLOW_INSECURE_REMOTE=0
+# Maximum decoded reference WAV size accepted by the Fish wrapper (default: 10 MiB).
+#FISH_S2_MAX_REF_AUDIO_BYTES=10485760
+# Shared fallback when the engine-specific reference-audio limit is unset.
+#TOMORI_TTS_MAX_REF_AUDIO_BYTES=10485760
+# Model repository and health metadata label for a custom checkpoint directory.
+#FISH_S2_MODEL_ID=Imagilux/fishaudio-s2-pro
+# Fish wrapper startup and launcher readiness limits.
+#FISH_S2_STARTUP_TIMEOUT_SECONDS=180
+#FISH_S2_LAUNCH_TIMEOUT_MS=240000
+#FISH_S2_SYNTHESIS_TIMEOUT_SECONDS=240
+# Installer revisions. Defaults are reviewed immutable commits; override only deliberately.
+#FISH_S2_RUNTIME_REPOSITORY=https://github.com/Imagilux/fish-speech.git
+#FISH_S2_RUNTIME_REF=2225e924e7d35cc0a1d24dbc67cd1819e6cf429f
+#FISH_S2_MODEL_REVISION=9706ff036580881d87cc09465dd10014527bc481
+# Set to 1 only for an explicit upstream update, optionally with *_UPDATE_REF variables.
+#FISH_S2_UPDATE=0
+#FISH_S2_UPDATE_REF=main
+#FISH_S2_UPDATE_MODEL_REVISION=main
 
 # Maximum tool names retained from the latest successful remote discovery (default: 100)
 MCP_TOOL_SNAPSHOT_MAX_NAMES=100

--- a/.env.optional.example
+++ b/.env.optional.example
@@ -391,7 +391,8 @@ TTS_SYNTHESIZE_TIMEOUT_MS=240000
 #FISH_S2_RUNTIME_REPOSITORY=https://github.com/Imagilux/fish-speech.git
 #FISH_S2_RUNTIME_REF=2225e924e7d35cc0a1d24dbc67cd1819e6cf429f
 #FISH_S2_MODEL_REVISION=9706ff036580881d87cc09465dd10014527bc481
-# Set to 1 only for an explicit upstream update, optionally with *_UPDATE_REF variables.
+# Set to 1 only for an explicit upstream update. An explicit *_UPDATE_REF wins over a base ref;
+# otherwise a configured base ref is preserved and an unconfigured ref updates to main.
 #FISH_S2_UPDATE=0
 #FISH_S2_UPDATE_REF=main
 #FISH_S2_UPDATE_MODEL_REVISION=main

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -131,3 +131,25 @@ jobs:
         # runTests.ts detects POSTGRES_PASSWORD, provisions a disposable
         # tomoribot_test_<id> database, injects TEST_DB_READY=1, and drops
         # the database after the suite completes (or on failure).
+
+  validate-fish-sidecar:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Fish sidecar test dependencies
+        run: |
+          python3 -m venv "$RUNNER_TEMP/fish-s2-test-venv"
+          "$RUNNER_TEMP/fish-s2-test-venv/bin/python" -m pip install --disable-pip-version-check -r servers/tts/fishs2/requirements.txt
+
+      - name: Compile Fish sidecar and run contract tests
+        working-directory: servers/tts/fishs2
+        run: |
+          "$RUNNER_TEMP/fish-s2-test-venv/bin/python" -m py_compile server.py test_server.py
+          "$RUNNER_TEMP/fish-s2-test-venv/bin/python" -m unittest discover -p 'test_*.py'
+
+      - name: Check Fish installer syntax
+        run: |
+          bash -n servers/tts/fishs2/install-fishs2.sh
+          pwsh -NoProfile -Command '$tokens = $null; $errors = $null; [System.Management.Automation.Language.Parser]::ParseFile("servers/tts/fishs2/install-fishs2.ps1", [ref]$tokens, [ref]$errors); if ($errors.Count -gt 0) { $errors | Format-List; exit 1 }'

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ bun run launch --qwen3tts
 bun run launch --help
 ```
 
-Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--whisperx`, `--help`
+Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--fishs2`, `--whisperx`, `--help`
 
 **Ctrl+C** stops the bot and any Python sidecar processes. Docker containers (`--searxng`, `--crawl4ai`) are intentionally left running, stop them manually with `docker stop searxng` / `docker stop crawl4ai` when you're done.
 

--- a/docs/en/self-hosting/local-endpoints/README.mdx
+++ b/docs/en/self-hosting/local-endpoints/README.mdx
@@ -34,7 +34,7 @@ Pick a capability to set up:
 
 <CardGrid>
   <LinkCard title="Text-to-Speech" href="/self-hosting/local-endpoints/text-to-speech/"
-    description="Local TTS engines (Chatterbox, Qwen3-TTS, IrodoriTTS) for native Discord voice messages with voice cloning." />
+    description="Local TTS engines (Chatterbox, Qwen3-TTS, IrodoriTTS, Fish S2 Pro) for native Discord voice messages and voice cloning." />
   <LinkCard title="Speech-to-Text" href="/self-hosting/local-endpoints/speech-to-text/"
     description="Transcribe audio attachments locally with WhisperX, whisper.cpp, or KoboldCPP." />
 </CardGrid>
@@ -68,12 +68,13 @@ bun run launch --searxng --crawl4ai
 
 # With a local TTS server (venv must be set up first — see the Text-to-Speech guide below)
 bun run launch --qwen3tts
+bun run launch --fishs2
 
 # See all available flags
 bun run launch --help
 ```
 
-Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--whisperx`
+Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--fishs2`, `--whisperx`
 
 Docker sidecars (`--searxng`, `--crawl4ai`) are created on first run and reused on subsequent runs. Python TTS/STT sidecars require their venv to be set up once beforehand; see the individual setup guides under [Text-to-Speech](/self-hosting/local-endpoints/text-to-speech/) and [Speech-to-Text](/self-hosting/local-endpoints/speech-to-text/).
 

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/README.mdx
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/README.mdx
@@ -17,9 +17,11 @@ TomoriBot treats speech as a custom endpoint capability. Local engines run outsi
   <LinkCard title="Chatterbox TTS" href="/self-hosting/local-endpoints/text-to-speech/chatterbox/"
     description="Fast local voice cloning through Chatterbox-Turbo, with supported bracket delivery tags for expressive speech." />
   <LinkCard title="Qwen3-TTS" href="/self-hosting/local-endpoints/text-to-speech/qwen3tts/"
-    description="Multilingual local TTS with clone and VoiceDesign modes. Largest but best quality." />
+    description="Multilingual local TTS with clone and VoiceDesign modes." />
   <LinkCard title="IrodoriTTS" href="/self-hosting/local-endpoints/text-to-speech/irodoritts/"
-    description="Japanese-focused voice cloning that preserves Unicode emoji markup for emotion control." />
+    description="Japanese-focused voice cloning and VoiceDesign with Unicode emoji markup for emotion control." />
+  <LinkCard title="Fish Audio S2 Pro" href="/self-hosting/local-endpoints/text-to-speech/fishs2/"
+    description="High-quality multilingual voice cloning with fine-grained bracket expression controls. Defaults to a 16 GB-friendly INT8 checkpoint." />
 </CardGrid>
 
 ## Setup Flow
@@ -36,27 +38,24 @@ For clone engines, add and assign one voice sample per persona:
 
 1. Prepare a clean 10-20 second clip with one speaker and no background music.
 2. Open `/config` under Models > TTS Parameters & Voices and upload the sample. Any audio format is accepted; TomoriBot converts it to mono WAV.
-3. Open `/config` under Persona > Voice, then choose the persona and voice sample.
+3. Provide a matching transcript when the engine benefits from it. Fish S2 Pro in particular forwards the stored reference transcript into the cloning request.
+4. Open `/config` under Persona > Voice, then choose the persona and voice sample.
 
-For Qwen3-TTS VoiceDesign, skip the audio sample and use Persona > Voice in `/config` for each persona instead.
+For Qwen3-TTS or Irodori VoiceDesign, skip the audio sample and use Persona > Voice in `/config` for each persona instead.
 
 ElevenLabs users should choose **Add New Provider** and **ElevenLabs** in `/providers`; it registers the speech and transcription endpoints together.
 
-TomoriBot strips Discord custom emoji syntax such as `:pepega:` or `<:pepega:123456789012345678>` from generated voice scripts before synthesis. Unicode emojis are also stripped unless the speech endpoint uses emoji markup, which is intended for IrodoriTTS.
+TomoriBot strips Discord custom emoji syntax such as `:pepega:` or `<:pepega:123456789012345678>` from generated voice scripts before synthesis. Unicode emojis are also stripped unless the speech endpoint uses emoji markup, which is intended for IrodoriTTS. Bracket tags are preserved for endpoints such as Chatterbox Turbo and Fish S2 Pro when their Script Markup is set to **Bracket Tags**.
 
 ## Hardware requirements
 
-Local TTS engines are **much lighter than an LLM** — these are small models (roughly
-0.5B–1.7B parameters). Even a modest NVIDIA GPU (a few GB of VRAM is plenty) runs any of them
-comfortably and keeps synthesis fast. They also run on **CPU** — slower, but workable, since
-voice clips are short.
+Hardware requirements differ substantially between engines. Chatterbox, Qwen3-TTS, and Irodori are relatively small; Fish S2 Pro is a 4B model and is much heavier.
 
 | Engine | Model size | Notes |
 |---|---|---|
-| Chatterbox | ~0.5B (Turbo) | Fastest current option. |
+| Chatterbox | ~0.5B (Turbo) | Fast local option with bracket delivery tags. |
 | Qwen3-TTS | 1.7B (12 Hz) | Separate clone + VoiceDesign models; only one loads at a time. |
-| IrodoriTTS | 500M (v2) | Japanese-focused; `bf16` on GPU, `fp32` on CPU. |
+| IrodoriTTS | ~0.5B | Japanese-focused clone + VoiceDesign. |
+| Fish S2 Pro | 4B | Official BF16 recommends 24 GB+ VRAM; TomoriBot defaults to an INT8 checkpoint intended for 16 GB consumer GPUs. |
 
-The first synthesis after startup (or after Qwen3-TTS swaps models in auto mode) is slower
-while the model loads into memory; later requests are fast. TomoriBot waits up to
-`TTS_SYNTHESIZE_TIMEOUT_MS` (default 240000 ms) for each response.
+The first synthesis after startup (or after Qwen3-TTS swaps models in auto mode) is slower while the model loads into memory. TomoriBot waits up to `TTS_SYNTHESIZE_TIMEOUT_MS` (default 240000 ms) for each response.

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
@@ -39,12 +39,27 @@ bash servers/tts/fishs2/install-fishs2.sh
 servers/tts/fishs2/.venv/bin/python servers/tts/fishs2/server.py
 ```
 
-The installer:
+The installer uses a reviewed runtime commit and model revision by default. It does not update a
+checkout from a moving branch during a normal reinstall. The installer:
 
-1. clones `Imagilux/fish-speech` into `servers/tts/fishs2/fish-speech/`;
+1. clones `Imagilux/fish-speech` into `servers/tts/fishs2/fish-speech/` and checks out the pinned runtime commit;
 2. creates the isolated `.venv`;
 3. installs Fish Speech plus the TomoriBot wrapper dependencies; and
-4. downloads `Imagilux/fishaudio-s2-pro` into `fish-speech/checkpoints/fish-speech-s2-pro-int8/`.
+4. downloads the pinned `Imagilux/fishaudio-s2-pro` revision into `fish-speech/checkpoints/fish-speech-s2-pro-int8/`.
+
+The reviewed defaults are runtime commit
+`2225e924e7d35cc0a1d24dbc67cd1819e6cf429f` and model revision
+`9706ff036580881d87cc09465dd10014527bc481`.
+
+To deliberately update or test another upstream revision, set `FISH_S2_RUNTIME_REF` and
+`FISH_S2_MODEL_REVISION` before running the installer. For a convenience update to upstream
+`main`, set `FISH_S2_UPDATE=1`; this is an explicit opt-in and uses `FISH_S2_UPDATE_REF` and
+`FISH_S2_UPDATE_MODEL_REVISION` when provided. Record any revision used for a deployment so it can
+be reproduced later.
+
+`FISH_S2_RUNTIME_REPOSITORY` can point at a reviewed mirror when required. `FISH_S2_MODEL_ID` and
+`FISH_S2_MODEL_REVISION` select the Hugging Face repository and immutable revision used by the
+installer.
 
 The Hugging Face model is gated. Accept its license on Hugging Face first. If the download asks for authentication, run:
 
@@ -65,7 +80,16 @@ Fish Audio officially documents Linux/WSL for local S2 inference, so WSL is pref
 
 If an upstream Fish Speech dependency fails to build on native Windows, use WSL instead.
 
-The TomoriBot wrapper listens on `http://127.0.0.1:8015`. Internally it starts Fish Speech's own API server on port `8025` and translates TomoriBot's `/synthesize` request into Fish's MessagePack API. This keeps Fish's inference implementation upstream while preserving TomoriBot's common TTS endpoint contract.
+The TomoriBot wrapper listens on `http://127.0.0.1:8015` by default. Internally it starts Fish
+Speech's own API server on port `8025` and translates TomoriBot's `/synthesize` request into Fish's
+MessagePack API. This keeps Fish's inference implementation upstream while preserving TomoriBot's
+common TTS endpoint contract.
+
+The wrapper binds to loopback by default. If `TOMORI_TTS_HOST` is changed to a non-loopback address,
+set `FISH_S2_API_KEY` and use the same value as the custom endpoint API key in TomoriBot. The
+wrapper then requires `Authorization: Bearer <key>` for `/health` and `/synthesize`. An unauthenticated
+remote bind is available only with the explicit `FISH_S2_ALLOW_INSECURE_REMOTE=1` opt-in and is not
+recommended.
 
 ## Register in TomoriBot
 
@@ -76,6 +100,7 @@ In `/providers`, choose **Add New Custom Endpoint** and configure:
 - Endpoint URL: `http://127.0.0.1:8015`
 - Voice Source Mode: `Clone`
 - Script Markup: `Bracket Tags`
+- API key: leave empty for the default loopback setup. If bearer auth is enabled, enter the exact `FISH_S2_API_KEY` value.
 
 Then add the endpoint's model entry and activate it through `/config` under Models > Switch Models.
 
@@ -105,8 +130,15 @@ Because the endpoint uses `Bracket Tags` markup, TomoriBot preserves these tags 
 |---|---|---|
 | `FISH_SPEECH_DIR` | `servers/tts/fishs2/fish-speech` | Fish Speech runtime directory |
 | `FISH_S2_MODEL_DIR` | `fish-speech/checkpoints/fish-speech-s2-pro-int8` | S2 Pro checkpoint directory |
+| `FISH_S2_MODEL_ID` | `Imagilux/fishaudio-s2-pro` | Model repository and health metadata label for the configured checkpoint |
 | `TOMORI_TTS_HOST` | `127.0.0.1` | TomoriBot wrapper bind address |
-| `TOMORI_TTS_PORT` | `8015` | TomoriBot wrapper port |
+| `FISH_S2_PORT` | `8015` | Fish wrapper port; falls back to `TOMORI_TTS_PORT` when unset |
+| `TOMORI_TTS_PORT` | unset | Backward-compatible shared port override |
+| `FISH_S2_API_KEY` | unset | Optional bearer token, also required for authenticated remote binds |
+| `TOMORI_TTS_API_KEY` | unset | Shared bearer-token fallback when `FISH_S2_API_KEY` is unset |
+| `FISH_S2_ALLOW_INSECURE_REMOTE` | `0` | Explicitly allow a non-loopback bind without a bearer token |
+| `FISH_S2_MAX_REF_AUDIO_BYTES` | `10485760` | Maximum decoded reference WAV size |
+| `TOMORI_TTS_MAX_REF_AUDIO_BYTES` | unset | Shared decoded reference-audio limit fallback |
 | `FISH_S2_UPSTREAM_HOST` | `127.0.0.1` | Internal Fish API bind address |
 | `FISH_S2_UPSTREAM_PORT` | `8025` | Internal Fish API port |
 | `FISH_S2_COMPILE` | `0` | Enable Fish Speech `torch.compile`; upstream notes that compile is not supported on native Windows/macOS without additional setup |
@@ -118,10 +150,19 @@ Because the endpoint uses `Bracket Tags` markup, TomoriBot preserves these tags 
 | `FISH_S2_MAX_NEW_TOKENS` | `1024` | Maximum semantic tokens generated per request |
 | `FISH_S2_USE_MEMORY_CACHE` | `on` | Cache encoded reference voices in the Fish runtime |
 | `TOMORI_TTS_MAX_TEXT_CHARS` | `2000` | Maximum script length accepted by the wrapper |
+| `FISH_S2_STARTUP_TIMEOUT_SECONDS` | `180` | Maximum time to wait for the nested Fish API |
+| `FISH_S2_SYNTHESIS_TIMEOUT_SECONDS` | `240` | Maximum time to wait for one upstream synthesis request |
+| `FISH_S2_LAUNCH_TIMEOUT_MS` | `240000` | Launcher JSON health readiness timeout |
+
+Reference audio must be a non-empty, uncompressed PCM RIFF/WAVE file. The decoded size limit is
+checked before inference to prevent an oversized base64 request from consuming unbounded memory.
 
 ## Use another S2 Pro checkpoint
 
-Set `FISH_S2_MODEL_DIR` before starting the wrapper. For example, a 24 GB+ GPU can use the official BF16 checkpoint downloaded from `fishaudio/s2-pro`.
+Set `FISH_S2_MODEL_DIR` and `FISH_S2_MODEL_ID` before starting the wrapper. For example, a 24 GB+
+GPU can use the official BF16 checkpoint downloaded from `fishaudio/s2-pro`. The health response
+reports the configured model ID and directory rather than claiming that every checkpoint is the
+default INT8 model.
 
 The checkpoint directory must contain the Fish model files and `codec.pth` expected by the selected Fish Speech runtime.
 

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
@@ -1,0 +1,130 @@
+---
+title: "Fish Audio S2 Pro"
+aiGenerated: false
+---
+
+Fish Audio S2 Pro is a multilingual 4B TTS model focused on high-fidelity voice cloning and expressive delivery. TomoriBot uses it through the local wrapper in `servers/tts/fishs2/`.
+
+The default TomoriBot setup uses `Imagilux/fishaudio-s2-pro`, an INT8 weight-only quantization of S2 Pro intended for VRAM-constrained consumer GPUs. The transformer is reduced from roughly 10.3 GB to roughly 5.1 GB while embeddings, layer norms, and the VQ-GAN codec remain in BF16. The model card reports about 10.9 GB total VRAM on a 16 GB Radeon test system and states that the checkpoint also works on NVIDIA CUDA.
+
+Fish S2 Pro supports bracket expression tags such as `[whisper]`, `[excited]`, and `[angry]`. Configure the endpoint with **Bracket Tags** markup so TomoriBot preserves these controls in generated voice scripts.
+
+## License
+
+Fish Speech code and S2 Pro model weights are distributed under the Fish Audio Research License. The default quantized checkpoint is also under that license. Research and non-commercial use are permitted under its terms; commercial use requires a separate Fish Audio license.
+
+TomoriBot does not redistribute the model weights. Each self-hosting user downloads Fish S2 Pro directly from Hugging Face and is responsible for complying with the Fish Audio Research License. The required attribution is: **Built with Fish Audio**.
+
+## Hardware
+
+The official BF16 S2 Pro setup recommends at least 24 GB of VRAM. TomoriBot therefore defaults to the INT8 checkpoint instead.
+
+Recommended starting point:
+
+- NVIDIA or AMD GPU with **16 GB VRAM or more**
+- Python 3.12 recommended
+- `git`, `ffmpeg`, and the normal system audio dependencies required by Fish Speech
+- Linux or WSL is the officially documented Fish Speech environment. Native Windows is best-effort.
+
+The INT8 checkpoint is primarily maintained for the Imagilux Fish Speech fork, which also adds VRAM management and consumer-GPU fixes. This is why the TomoriBot installer uses that runtime rather than the upstream Fish Speech repository by default.
+
+## Setup
+
+### Linux / WSL
+
+From the TomoriBot repository root:
+
+```bash
+bash servers/tts/fishs2/install-fishs2.sh
+servers/tts/fishs2/.venv/bin/python servers/tts/fishs2/server.py
+```
+
+The installer:
+
+1. clones `Imagilux/fish-speech` into `servers/tts/fishs2/fish-speech/`;
+2. creates the isolated `.venv`;
+3. installs Fish Speech plus the TomoriBot wrapper dependencies; and
+4. downloads `Imagilux/fishaudio-s2-pro` into `fish-speech/checkpoints/fish-speech-s2-pro-int8/`.
+
+The Hugging Face model is gated. Accept its license on Hugging Face first. If the download asks for authentication, run:
+
+```bash
+servers/tts/fishs2/.venv/bin/hf auth login
+```
+
+Then rerun the installer.
+
+### Windows PowerShell
+
+Fish Audio officially documents Linux/WSL for local S2 inference, so WSL is preferred. A best-effort native Windows installer is included:
+
+```powershell
+.\servers\tts\fishs2\install-fishs2.ps1
+.\servers\tts\fishs2\.venv\Scripts\python.exe servers\tts\fishs2\server.py
+```
+
+If an upstream Fish Speech dependency fails to build on native Windows, use WSL instead.
+
+The TomoriBot wrapper listens on `http://127.0.0.1:8015`. Internally it starts Fish Speech's own API server on port `8025` and translates TomoriBot's `/synthesize` request into Fish's MessagePack API. This keeps Fish's inference implementation upstream while preserving TomoriBot's common TTS endpoint contract.
+
+## Register in TomoriBot
+
+In `/providers`, choose **Add New Custom Endpoint** and configure:
+
+- Capability: `Speech`
+- API Compatibility: `tts-clone`
+- Endpoint URL: `http://127.0.0.1:8015`
+- Voice Source Mode: `Clone`
+- Script Markup: `Bracket Tags`
+
+Then add the endpoint's model entry and activate it through `/config` under Models > Switch Models.
+
+## Add persona voices
+
+1. Prepare a clean reference clip with one speaker and little or no background noise.
+2. In `/config`, open Models > TTS Parameters & Voices and upload the voice sample.
+3. Provide the transcript of the reference clip when possible.
+4. In `/config`, open Persona > Voice and assign the sample to the persona.
+5. Generate a voice message with `/generate voice-message` or let TomoriBot generate one through its voice-message tool.
+
+The reference transcript matters for Fish cloning quality. TomoriBot already stores it with each voice sample, and the Fish sidecar forwards both the reference WAV and `ref_text` to S2 Pro.
+
+## Expression controls
+
+Fish S2 Pro can vary delivery within one utterance using bracket tags. For example:
+
+```text
+[whisper] Keep your voice down. [excited] Wait, you actually found it?
+```
+
+Because the endpoint uses `Bracket Tags` markup, TomoriBot preserves these tags instead of stripping them before synthesis.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `FISH_SPEECH_DIR` | `servers/tts/fishs2/fish-speech` | Fish Speech runtime directory |
+| `FISH_S2_MODEL_DIR` | `fish-speech/checkpoints/fish-speech-s2-pro-int8` | S2 Pro checkpoint directory |
+| `TOMORI_TTS_HOST` | `127.0.0.1` | TomoriBot wrapper bind address |
+| `TOMORI_TTS_PORT` | `8015` | TomoriBot wrapper port |
+| `FISH_S2_UPSTREAM_HOST` | `127.0.0.1` | Internal Fish API bind address |
+| `FISH_S2_UPSTREAM_PORT` | `8025` | Internal Fish API port |
+| `FISH_S2_COMPILE` | `0` | Enable Fish Speech `torch.compile`; upstream notes that compile is not supported on native Windows/macOS without additional setup |
+| `FISH_S2_HALF` | `0` | Request FP16 runtime mode; leave disabled for the default INT8 checkpoint unless you have tested it |
+| `FISH_S2_CHUNK_LENGTH` | `200` | Fish iterative prompt chunk length |
+| `FISH_S2_TOP_P` | `0.8` | Sampling top-p |
+| `FISH_S2_TEMPERATURE` | `0.8` | Sampling temperature |
+| `FISH_S2_REPETITION_PENALTY` | `1.1` | Repetition penalty |
+| `FISH_S2_MAX_NEW_TOKENS` | `1024` | Maximum semantic tokens generated per request |
+| `FISH_S2_USE_MEMORY_CACHE` | `on` | Cache encoded reference voices in the Fish runtime |
+| `TOMORI_TTS_MAX_TEXT_CHARS` | `2000` | Maximum script length accepted by the wrapper |
+
+## Use another S2 Pro checkpoint
+
+Set `FISH_S2_MODEL_DIR` before starting the wrapper. For example, a 24 GB+ GPU can use the official BF16 checkpoint downloaded from `fishaudio/s2-pro`.
+
+The checkpoint directory must contain the Fish model files and `codec.pth` expected by the selected Fish Speech runtime.
+
+## Why INT8 is the default
+
+The goal is to keep the high-quality S2 Pro voice model usable on common 16 GB GPUs without making a more aggressive 4-bit quantization the default. The Imagilux model card reports only a very small WER difference from BF16 and keeps several quality-sensitive components in BF16, so INT8 is the current TomoriBot default for this sidecar.

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md
@@ -55,7 +55,8 @@ To deliberately update or test another upstream revision, set `FISH_S2_RUNTIME_R
 `FISH_S2_MODEL_REVISION` before running the installer. For a convenience update to upstream
 `main`, set `FISH_S2_UPDATE=1`; this is an explicit opt-in and uses `FISH_S2_UPDATE_REF` and
 `FISH_S2_UPDATE_MODEL_REVISION` when provided. Record any revision used for a deployment so it can
-be reproduced later.
+be reproduced later. An explicit update ref wins over a base ref. When no update ref is supplied,
+an explicitly configured base ref remains selected; otherwise the update opt-in selects `main`.
 
 `FISH_S2_RUNTIME_REPOSITORY` can point at a reviewed mirror when required. `FISH_S2_MODEL_ID` and
 `FISH_S2_MODEL_REVISION` select the Hugging Face repository and immutable revision used by the

--- a/scripts/devtools/launch.ts
+++ b/scripts/devtools/launch.ts
@@ -9,7 +9,7 @@ config();
 
 // scripts/devtools/launch.ts
 //
-//   bun run launch [--searxng] [--crawl4ai] [--qwen3tts] [--chatterbox] [--irodoritts]
+//   bun run launch [--searxng] [--crawl4ai] [--qwen3tts] [--chatterbox] [--irodoritts] [--fishs2]
 //
 //   Starts requested sidecar services, waits for them to be ready, then
 //   launches the bot in watch mode (equivalent to `bun run dev`).
@@ -21,7 +21,6 @@ config();
 //   Press Ctrl+C to stop everything.
 
 const ROOT = process.cwd();
-
 
 const argv = process.argv.slice(2);
 const flags = new Set(argv.filter((a) => a.startsWith("--")).map((a) => a.slice(2)));
@@ -39,6 +38,7 @@ ${pc.bold("Options:")}
   --qwen3tts    Start the Qwen3-TTS Python server (requires venv setup)
   --chatterbox  Start the Chatterbox TTS Python server (requires venv setup)
   --irodoritts  Start the IrodoriTTS Python server (requires venv setup)
+  --fishs2      Start the Fish Audio S2 Pro Python server (requires venv + model setup)
   --whisperx    Start the WhisperX transcription Python server (requires venv setup)
   --help        Show this message
 
@@ -46,10 +46,10 @@ ${pc.bold("Examples:")}
   bun run launch
   bun run launch --searxng --crawl4ai
   bun run launch --qwen3tts --searxng
+  bun run launch --fishs2
 `);
   process.exit(0);
 }
-
 
 interface DockerSidecar {
   kind: "docker";
@@ -152,6 +152,14 @@ const SIDECARS: Record<string, SidecarDef> = {
     startupDelayMs: 8_000,
   },
 
+  fishs2: {
+    kind: "python",
+    displayName: "Fish S2 Pro",
+    venvRelPath: "servers/tts/fishs2/.venv",
+    scriptRelPath: "servers/tts/fishs2/server.py",
+    startupDelayMs: 12_000,
+  },
+
   whisperx: {
     kind: "python",
     displayName: "WhisperX",
@@ -160,7 +168,6 @@ const SIDECARS: Record<string, SidecarDef> = {
     startupDelayMs: 10_000,
   },
 };
-
 
 /**
  * Checks whether a named Docker container exists (regardless of state).
@@ -256,7 +263,6 @@ async function ensureDockerSidecar(def: DockerSidecar): Promise<void> {
   console.log(`${label} ${pc.green("Healthy ✓")}`);
 }
 
-
 /**
  * Spawns a Python sidecar server from its pre-built venv and waits
  * `startupDelayMs` milliseconds for it to bind before returning the handle.
@@ -290,7 +296,6 @@ async function startPythonSidecar(def: PythonSidecar): Promise<ReturnType<typeof
 
   return proc;
 }
-
 
 async function main(): Promise<void> {
   const requested = [...flags].filter((f) => f in SIDECARS);

--- a/scripts/devtools/launch.ts
+++ b/scripts/devtools/launch.ts
@@ -80,9 +80,20 @@ interface PythonSidecar {
   scriptArgs?: string[];
   /** milliseconds to wait after spawn before proceeding (default 3s) */
   startupDelayMs?: number;
+  /** JSON health endpoint that must report {"status":"ok"} before startup succeeds. */
+  httpHealthUrl?: string;
+  /** milliseconds to wait for the health endpoint (default 120s) */
+  healthTimeoutMs?: number;
+  /** headers sent to the health endpoint, such as a configured bearer token */
+  healthHeaders?: Record<string, string>;
 }
 
 type SidecarDef = DockerSidecar | PythonSidecar;
+
+function parsePositiveMilliseconds(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 /** Registry of all supported --flag → sidecar definitions. */
 const SIDECARS: Record<string, SidecarDef> = {
@@ -157,7 +168,13 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "Fish S2 Pro",
     venvRelPath: "servers/tts/fishs2/.venv",
     scriptRelPath: "servers/tts/fishs2/server.py",
-    startupDelayMs: 12_000,
+    httpHealthUrl: `http://127.0.0.1:${process.env.FISH_S2_PORT ?? process.env.TOMORI_TTS_PORT ?? "8015"}/health`,
+    healthTimeoutMs: parsePositiveMilliseconds(process.env.FISH_S2_LAUNCH_TIMEOUT_MS, 240_000),
+    healthHeaders: {
+      ...(process.env.FISH_S2_API_KEY || process.env.TOMORI_TTS_API_KEY
+        ? { Authorization: `Bearer ${process.env.FISH_S2_API_KEY ?? process.env.TOMORI_TTS_API_KEY}` }
+        : {}),
+    },
   },
 
   whisperx: {
@@ -263,13 +280,68 @@ async function ensureDockerSidecar(def: DockerSidecar): Promise<void> {
   console.log(`${label} ${pc.green("Healthy ✓")}`);
 }
 
+type PythonReadinessResult =
+  | { kind: "exit"; code: number }
+  | { kind: "delay" }
+  | { kind: "health"; ready: boolean };
+
+async function probePythonHealth(url: string, headers: Record<string, string>): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!response.ok) return false;
+    const body: unknown = await response.json();
+    return typeof body === "object" && body !== null && "status" in body && body.status === "ok";
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPythonReadiness(
+  proc: ReturnType<typeof Bun.spawn>,
+  def: PythonSidecar,
+  label: string,
+): Promise<void> {
+  const childExit = proc.exited.then((code): PythonReadinessResult => ({ kind: "exit", code }));
+  if (def.httpHealthUrl) {
+    const timeoutMs = def.healthTimeoutMs ?? 120_000;
+    const deadline = Date.now() + timeoutMs;
+    console.log(`${label} Waiting for JSON health readiness (timeout ${timeoutMs / 1000}s)...`);
+    while (Date.now() < deadline) {
+      const result = await Promise.race([
+        childExit,
+        probePythonHealth(def.httpHealthUrl, def.healthHeaders ?? {}).then(
+          (ready): PythonReadinessResult => ({ kind: "health", ready }),
+        ),
+      ]);
+      if (result.kind === "exit") {
+        throw new Error(`${label} exited during startup with code ${result.code}.`);
+      }
+      if (result.kind === "health" && result.ready) return;
+      await Bun.sleep(1_000);
+    }
+    throw new Error(`${label} did not report JSON health status ok within ${timeoutMs / 1000}s.`);
+  }
+
+  const startupDelayMs = def.startupDelayMs ?? 3_000;
+  console.log(`${label} Waiting ${startupDelayMs / 1000}s for server to initialize...`);
+  const result = await Promise.race([
+    childExit,
+    Bun.sleep(startupDelayMs).then((): PythonReadinessResult => ({ kind: "delay" })),
+  ]);
+  if (result.kind === "exit") {
+    throw new Error(`${label} exited during startup with code ${result.code}.`);
+  }
+}
+
 /**
- * Spawns a Python sidecar server from its pre-built venv and waits
- * `startupDelayMs` milliseconds for it to bind before returning the handle.
- * Throws if the venv is missing (user must run setup first).
+ * Spawns a Python sidecar server from its pre-built venv and waits for either
+ * its JSON health endpoint or its configured compatibility delay.
  */
 async function startPythonSidecar(def: PythonSidecar): Promise<ReturnType<typeof Bun.spawn>> {
-  const { displayName, venvRelPath, scriptRelPath, scriptArgs = [], startupDelayMs = 3_000 } = def;
+  const { displayName, venvRelPath, scriptRelPath, scriptArgs = [] } = def;
   const label = pc.magenta(`[${displayName}]`);
 
   const pythonExe = resolvePythonExe(venvRelPath);
@@ -289,9 +361,12 @@ async function startPythonSidecar(def: PythonSidecar): Promise<ReturnType<typeof
     cwd: ROOT,
   });
 
-  // Give the Python HTTP server time to bind its port.
-  console.log(`${label} Waiting ${startupDelayMs / 1000}s for server to initialize...`);
-  await Bun.sleep(startupDelayMs);
+  try {
+    await waitForPythonReadiness(proc, def, label);
+  } catch (error) {
+    try { proc.kill(); } catch { /* process may have exited already */ }
+    throw error;
+  }
   console.log(`${label} ${pc.green("Started ✓")}`);
 
   return proc;

--- a/servers/tts/README.md
+++ b/servers/tts/README.md
@@ -10,6 +10,7 @@ Each engine lives in its own subfolder with its own `.venv` to keep dependencies
 | Qwen3-TTS 12Hz 1.7B Base / VoiceDesign auto mode (10 languages, plain text) | `qwen3tts/` | 8012 |
 | Irodori-TTS v4.1 (Japanese, clone + VoiceDesign, emoji tags) | `irodoritts/` | 8013 |
 | Qwen3-TTS 12Hz 1.7B VoiceDesign (natural-language voice descriptions) | `qwen3tts/server.py --mode voice-design` | 8014 |
+| Fish Audio S2 Pro INT8 (multilingual cloning, bracket expression tags) | `fishs2/` | 8015 |
 
 ## Prerequisites
 
@@ -44,6 +45,8 @@ python servers\tts\chatterbox\server.py
 
 Qwen3-TTS follows a similar venv + requirements flow. Irodori-TTS uses `uv` and backend extras instead; see `docs/en/self-hosting/local-endpoints/text-to-speech/irodoritts.md` for its current setup.
 
+Fish S2 Pro has its own installer because the sidecar also installs the Fish Speech runtime and downloads the quantized checkpoint. See `docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md`. The default `Imagilux/fishaudio-s2-pro` checkpoint uses INT8 weight-only quantization and is intended to fit consumer GPUs with 16 GB VRAM while keeping the codec, embeddings, and layer norms in BF16.
+
 ## Registering in TomoriBot
 
 After the server is running, register it with `/provider custom-endpoint add`:
@@ -61,3 +64,5 @@ Chatterbox defaults to Turbo. Use `/config` under Models > TTS Parameters & Voic
 Qwen3-TTS defaults to auto mode. One server URL can handle both clone and VoiceDesign requests: the server detects clone requests by `ref_audio`, detects VoiceDesign requests by `instruct`, and swaps the loaded model when needed. Start VoiceDesign only with `TOMORI_TTS_MODE=voice-design python servers/tts/qwen3tts/server.py` or `python servers/tts/qwen3tts/server.py --mode voice-design`. In TomoriBot, set persona prompts with `/speech voice-design set`; generated tool calls send that prompt as `instruct`.
 
 Irodori-TTS v4.1 also supports TomoriBot's `Auto` voice source mode from one endpoint. Clone requests use `ref_audio`; VoiceDesign requests use `instruct`, which the wrapper maps to Irodori caption conditioning.
+
+Fish S2 Pro is registered as a cloning endpoint with `Bracket Tags` markup. TomoriBot sends the stored reference WAV and transcript directly to Fish, while expression tags such as `[whisper]`, `[excited]`, and `[angry]` remain in the generated script for Fish's fine-grained delivery control.

--- a/servers/tts/README.md
+++ b/servers/tts/README.md
@@ -45,7 +45,7 @@ python servers\tts\chatterbox\server.py
 
 Qwen3-TTS follows a similar venv + requirements flow. Irodori-TTS uses `uv` and backend extras instead; see `docs/en/self-hosting/local-endpoints/text-to-speech/irodoritts.md` for its current setup.
 
-Fish S2 Pro has its own installer because the sidecar also installs the Fish Speech runtime and downloads the quantized checkpoint. See `docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md`. The default `Imagilux/fishaudio-s2-pro` checkpoint uses INT8 weight-only quantization and is intended to fit consumer GPUs with 16 GB VRAM while keeping the codec, embeddings, and layer norms in BF16.
+Fish S2 Pro has its own installer because the sidecar also installs the Fish Speech runtime and downloads the quantized checkpoint. See `docs/en/self-hosting/local-endpoints/text-to-speech/fishs2.md`. The default `Imagilux/fishaudio-s2-pro` checkpoint uses INT8 weight-only quantization and is intended to fit consumer GPUs with 16 GB VRAM while keeping the codec, embeddings, and layer norms in BF16. The installer pins both upstream revisions and requires an explicit override for updates.
 
 ## Registering in TomoriBot
 
@@ -66,3 +66,5 @@ Qwen3-TTS defaults to auto mode. One server URL can handle both clone and VoiceD
 Irodori-TTS v4.1 also supports TomoriBot's `Auto` voice source mode from one endpoint. Clone requests use `ref_audio`; VoiceDesign requests use `instruct`, which the wrapper maps to Irodori caption conditioning.
 
 Fish S2 Pro is registered as a cloning endpoint with `Bracket Tags` markup. TomoriBot sends the stored reference WAV and transcript directly to Fish, while expression tags such as `[whisper]`, `[excited]`, and `[angry]` remain in the generated script for Fish's fine-grained delivery control.
+
+Fish's wrapper accepts PCM WAV references up to the configured decoded-audio limit and binds to loopback by default. Configure a bearer token before exposing it on a non-loopback address.

--- a/servers/tts/fishs2/.gitignore
+++ b/servers/tts/fishs2/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+fish-speech/

--- a/servers/tts/fishs2/install-fishs2.ps1
+++ b/servers/tts/fishs2/install-fishs2.ps1
@@ -8,7 +8,18 @@ $RuntimeDir = Join-Path $ScriptDir "fish-speech"
 $VenvDir = Join-Path $ScriptDir ".venv"
 $VenvPython = Join-Path $VenvDir "Scripts\python.exe"
 $HfExe = Join-Path $VenvDir "Scripts\hf.exe"
-$ModelDir = Join-Path $RuntimeDir "checkpoints\fish-speech-s2-pro-int8"
+$ModelDir = if ($env:FISH_S2_MODEL_DIR) { $env:FISH_S2_MODEL_DIR } else { Join-Path $RuntimeDir "checkpoints\fish-speech-s2-pro-int8" }
+$RuntimeRepository = if ($env:FISH_S2_RUNTIME_REPOSITORY) { $env:FISH_S2_RUNTIME_REPOSITORY } else { "https://github.com/Imagilux/fish-speech.git" }
+$RuntimeRef = if ($env:FISH_S2_RUNTIME_REF) { $env:FISH_S2_RUNTIME_REF } else { "2225e924e7d35cc0a1d24dbc67cd1819e6cf429f" }
+$ModelId = if ($env:FISH_S2_MODEL_ID) { $env:FISH_S2_MODEL_ID } else { "Imagilux/fishaudio-s2-pro" }
+$ModelRevision = if ($env:FISH_S2_MODEL_REVISION) { $env:FISH_S2_MODEL_REVISION } else { "9706ff036580881d87cc09465dd10014527bc481" }
+$UpdateRuntime = $env:FISH_S2_UPDATE -match "^(1|true|yes|on)$"
+if ($UpdateRuntime -and -not $env:FISH_S2_RUNTIME_REF) {
+  $RuntimeRef = if ($env:FISH_S2_UPDATE_REF) { $env:FISH_S2_UPDATE_REF } else { "main" }
+}
+if ($UpdateRuntime -and -not $env:FISH_S2_MODEL_REVISION) {
+  $ModelRevision = if ($env:FISH_S2_UPDATE_MODEL_REVISION) { $env:FISH_S2_UPDATE_MODEL_REVISION } else { "main" }
+}
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
   throw "git is required."
@@ -18,24 +29,27 @@ if (-not (Get-Command $Python -ErrorAction SilentlyContinue)) {
 }
 
 if (-not (Test-Path (Join-Path $RuntimeDir ".git"))) {
-  git clone https://github.com/Imagilux/fish-speech.git $RuntimeDir
-} else {
-  git -C $RuntimeDir pull --ff-only
+  git clone --no-checkout $RuntimeRepository $RuntimeDir
 }
+
+git -C $RuntimeDir fetch --depth 1 origin $RuntimeRef
+git -C $RuntimeDir checkout --detach --force $RuntimeRef
 
 & $Python -m venv $VenvDir
 & $VenvPython -m pip install --upgrade pip setuptools wheel
 & $VenvPython -m pip install -r (Join-Path $ScriptDir "requirements.txt")
 & $VenvPython -m pip install -e $RuntimeDir
 
-if (-not (Test-Path (Join-Path $ModelDir "model.pth")) -or -not (Test-Path (Join-Path $ModelDir "codec.pth"))) {
-  Write-Host "Downloading Imagilux/fishaudio-s2-pro INT8 checkpoint..."
+if ($UpdateRuntime -or -not (Test-Path (Join-Path $ModelDir "model.pth")) -or -not (Test-Path (Join-Path $ModelDir "codec.pth"))) {
+  Write-Host "Downloading $ModelId checkpoint at revision $ModelRevision..."
   Write-Host "If Hugging Face requests authentication, accept the model license and run: hf auth login"
-  & $HfExe download Imagilux/fishaudio-s2-pro --local-dir $ModelDir
+  & $HfExe download $ModelId --revision $ModelRevision --local-dir $ModelDir
 }
 
 Write-Host "Fish S2 Pro setup complete."
 Write-Host "Runtime: $RuntimeDir"
+Write-Host "Runtime ref: $RuntimeRef"
 Write-Host "Model:   $ModelDir"
+Write-Host "Model ref: $ModelRevision"
 Write-Host "Start:   $VenvPython $(Join-Path $ScriptDir 'server.py')"
 Write-Warning "Fish Audio officially documents Linux/WSL for local S2 inference. Native Windows is best-effort; use WSL if upstream dependencies fail to build."

--- a/servers/tts/fishs2/install-fishs2.ps1
+++ b/servers/tts/fishs2/install-fishs2.ps1
@@ -1,0 +1,41 @@
+param(
+  [string]$Python = "python"
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RuntimeDir = Join-Path $ScriptDir "fish-speech"
+$VenvDir = Join-Path $ScriptDir ".venv"
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+$HfExe = Join-Path $VenvDir "Scripts\hf.exe"
+$ModelDir = Join-Path $RuntimeDir "checkpoints\fish-speech-s2-pro-int8"
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  throw "git is required."
+}
+if (-not (Get-Command $Python -ErrorAction SilentlyContinue)) {
+  throw "$Python was not found. Python 3.12 is recommended by Fish Speech."
+}
+
+if (-not (Test-Path (Join-Path $RuntimeDir ".git"))) {
+  git clone https://github.com/Imagilux/fish-speech.git $RuntimeDir
+} else {
+  git -C $RuntimeDir pull --ff-only
+}
+
+& $Python -m venv $VenvDir
+& $VenvPython -m pip install --upgrade pip setuptools wheel
+& $VenvPython -m pip install -r (Join-Path $ScriptDir "requirements.txt")
+& $VenvPython -m pip install -e $RuntimeDir
+
+if (-not (Test-Path (Join-Path $ModelDir "model.pth")) -or -not (Test-Path (Join-Path $ModelDir "codec.pth"))) {
+  Write-Host "Downloading Imagilux/fishaudio-s2-pro INT8 checkpoint..."
+  Write-Host "If Hugging Face requests authentication, accept the model license and run: hf auth login"
+  & $HfExe download Imagilux/fishaudio-s2-pro --local-dir $ModelDir
+}
+
+Write-Host "Fish S2 Pro setup complete."
+Write-Host "Runtime: $RuntimeDir"
+Write-Host "Model:   $ModelDir"
+Write-Host "Start:   $VenvPython $(Join-Path $ScriptDir 'server.py')"
+Write-Warning "Fish Audio officially documents Linux/WSL for local S2 inference. Native Windows is best-effort; use WSL if upstream dependencies fail to build."

--- a/servers/tts/fishs2/install-fishs2.ps1
+++ b/servers/tts/fishs2/install-fishs2.ps1
@@ -14,11 +14,19 @@ $RuntimeRef = if ($env:FISH_S2_RUNTIME_REF) { $env:FISH_S2_RUNTIME_REF } else { 
 $ModelId = if ($env:FISH_S2_MODEL_ID) { $env:FISH_S2_MODEL_ID } else { "Imagilux/fishaudio-s2-pro" }
 $ModelRevision = if ($env:FISH_S2_MODEL_REVISION) { $env:FISH_S2_MODEL_REVISION } else { "9706ff036580881d87cc09465dd10014527bc481" }
 $UpdateRuntime = $env:FISH_S2_UPDATE -match "^(1|true|yes|on)$"
-if ($UpdateRuntime -and -not $env:FISH_S2_RUNTIME_REF) {
-  $RuntimeRef = if ($env:FISH_S2_UPDATE_REF) { $env:FISH_S2_UPDATE_REF } else { "main" }
+if ($UpdateRuntime) {
+  if ($env:FISH_S2_UPDATE_REF) {
+    $RuntimeRef = $env:FISH_S2_UPDATE_REF
+  } elseif (-not $env:FISH_S2_RUNTIME_REF) {
+    $RuntimeRef = "main"
+  }
 }
-if ($UpdateRuntime -and -not $env:FISH_S2_MODEL_REVISION) {
-  $ModelRevision = if ($env:FISH_S2_UPDATE_MODEL_REVISION) { $env:FISH_S2_UPDATE_MODEL_REVISION } else { "main" }
+if ($UpdateRuntime) {
+  if ($env:FISH_S2_UPDATE_MODEL_REVISION) {
+    $ModelRevision = $env:FISH_S2_UPDATE_MODEL_REVISION
+  } elseif (-not $env:FISH_S2_MODEL_REVISION) {
+    $ModelRevision = "main"
+  }
 }
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {

--- a/servers/tts/fishs2/install-fishs2.sh
+++ b/servers/tts/fishs2/install-fishs2.sh
@@ -4,8 +4,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNTIME_DIR="${SCRIPT_DIR}/fish-speech"
 VENV_DIR="${SCRIPT_DIR}/.venv"
-MODEL_DIR="${RUNTIME_DIR}/checkpoints/fish-speech-s2-pro-int8"
+MODEL_DIR="${FISH_S2_MODEL_DIR:-${RUNTIME_DIR}/checkpoints/fish-speech-s2-pro-int8}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
+RUNTIME_REPOSITORY="${FISH_S2_RUNTIME_REPOSITORY:-https://github.com/Imagilux/fish-speech.git}"
+RUNTIME_REF="${FISH_S2_RUNTIME_REF:-2225e924e7d35cc0a1d24dbc67cd1819e6cf429f}"
+MODEL_ID="${FISH_S2_MODEL_ID:-Imagilux/fishaudio-s2-pro}"
+MODEL_REVISION="${FISH_S2_MODEL_REVISION:-9706ff036580881d87cc09465dd10014527bc481}"
+UPDATE_RUNTIME="${FISH_S2_UPDATE:-0}"
+
+if [[ "${UPDATE_RUNTIME,,}" =~ ^(1|true|yes|on)$ ]]; then
+  RUNTIME_REF="${FISH_S2_UPDATE_REF:-main}"
+  MODEL_REVISION="${FISH_S2_UPDATE_MODEL_REVISION:-main}"
+fi
 
 if ! command -v git >/dev/null 2>&1; then
   echo "git is required." >&2
@@ -17,25 +27,28 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
 fi
 
 if [ ! -d "$RUNTIME_DIR/.git" ]; then
-  git clone https://github.com/Imagilux/fish-speech.git "$RUNTIME_DIR"
-else
-  git -C "$RUNTIME_DIR" pull --ff-only
+  git clone --no-checkout "$RUNTIME_REPOSITORY" "$RUNTIME_DIR"
 fi
+
+git -C "$RUNTIME_DIR" fetch --depth 1 origin "$RUNTIME_REF"
+git -C "$RUNTIME_DIR" checkout --detach --force "$RUNTIME_REF"
 
 "$PYTHON_BIN" -m venv "$VENV_DIR"
 "$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel
 "$VENV_DIR/bin/python" -m pip install -r "$SCRIPT_DIR/requirements.txt"
 "$VENV_DIR/bin/python" -m pip install -e "$RUNTIME_DIR"
 
-if [ ! -f "$MODEL_DIR/model.pth" ] || [ ! -f "$MODEL_DIR/codec.pth" ]; then
-  echo "Downloading Imagilux/fishaudio-s2-pro INT8 checkpoint..."
+if [[ "${UPDATE_RUNTIME,,}" =~ ^(1|true|yes|on)$ ]] || [ ! -f "$MODEL_DIR/model.pth" ] || [ ! -f "$MODEL_DIR/codec.pth" ]; then
+  echo "Downloading ${MODEL_ID} checkpoint at revision ${MODEL_REVISION}..."
   echo "If Hugging Face requests authentication, accept the model license and run: hf auth login"
-  "$VENV_DIR/bin/hf" download Imagilux/fishaudio-s2-pro --local-dir "$MODEL_DIR"
+  "$VENV_DIR/bin/hf" download "$MODEL_ID" --revision "$MODEL_REVISION" --local-dir "$MODEL_DIR"
 fi
 
 cat <<EOF
 Fish S2 Pro setup complete.
 Runtime: $RUNTIME_DIR
+Runtime ref: $RUNTIME_REF
 Model:   $MODEL_DIR
+Model ref: $MODEL_REVISION
 Start:   $VENV_DIR/bin/python $SCRIPT_DIR/server.py
 EOF

--- a/servers/tts/fishs2/install-fishs2.sh
+++ b/servers/tts/fishs2/install-fishs2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_DIR="${SCRIPT_DIR}/fish-speech"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+MODEL_DIR="${RUNTIME_DIR}/checkpoints/fish-speech-s2-pro-int8"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required." >&2
+  exit 1
+fi
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "$PYTHON_BIN is required (Python 3.10+; Python 3.12 recommended by Fish Speech)." >&2
+  exit 1
+fi
+
+if [ ! -d "$RUNTIME_DIR/.git" ]; then
+  git clone https://github.com/Imagilux/fish-speech.git "$RUNTIME_DIR"
+else
+  git -C "$RUNTIME_DIR" pull --ff-only
+fi
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+"$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel
+"$VENV_DIR/bin/python" -m pip install -r "$SCRIPT_DIR/requirements.txt"
+"$VENV_DIR/bin/python" -m pip install -e "$RUNTIME_DIR"
+
+if [ ! -f "$MODEL_DIR/model.pth" ] || [ ! -f "$MODEL_DIR/codec.pth" ]; then
+  echo "Downloading Imagilux/fishaudio-s2-pro INT8 checkpoint..."
+  echo "If Hugging Face requests authentication, accept the model license and run: hf auth login"
+  "$VENV_DIR/bin/hf" download Imagilux/fishaudio-s2-pro --local-dir "$MODEL_DIR"
+fi
+
+cat <<EOF
+Fish S2 Pro setup complete.
+Runtime: $RUNTIME_DIR
+Model:   $MODEL_DIR
+Start:   $VENV_DIR/bin/python $SCRIPT_DIR/server.py
+EOF

--- a/servers/tts/fishs2/install-fishs2.sh
+++ b/servers/tts/fishs2/install-fishs2.sh
@@ -13,8 +13,16 @@ MODEL_REVISION="${FISH_S2_MODEL_REVISION:-9706ff036580881d87cc09465dd10014527bc4
 UPDATE_RUNTIME="${FISH_S2_UPDATE:-0}"
 
 if [[ "${UPDATE_RUNTIME,,}" =~ ^(1|true|yes|on)$ ]]; then
-  RUNTIME_REF="${FISH_S2_UPDATE_REF:-main}"
-  MODEL_REVISION="${FISH_S2_UPDATE_MODEL_REVISION:-main}"
+  if [ -n "${FISH_S2_UPDATE_REF:-}" ]; then
+    RUNTIME_REF="$FISH_S2_UPDATE_REF"
+  elif [ -z "${FISH_S2_RUNTIME_REF:-}" ]; then
+    RUNTIME_REF="main"
+  fi
+  if [ -n "${FISH_S2_UPDATE_MODEL_REVISION:-}" ]; then
+    MODEL_REVISION="$FISH_S2_UPDATE_MODEL_REVISION"
+  elif [ -z "${FISH_S2_MODEL_REVISION:-}" ]; then
+    MODEL_REVISION="main"
+  fi
 fi
 
 if ! command -v git >/dev/null 2>&1; then

--- a/servers/tts/fishs2/requirements.txt
+++ b/servers/tts/fishs2/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+ormsgpack>=1.7.0
+huggingface_hub>=0.27.0

--- a/servers/tts/fishs2/requirements.txt
+++ b/servers/tts/fishs2/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.115.0
 uvicorn>=0.30.0
 ormsgpack>=1.7.0
-huggingface_hub>=0.27.0
+huggingface_hub>=0.34.0

--- a/servers/tts/fishs2/server.py
+++ b/servers/tts/fishs2/server.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import atexit
+import base64
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Optional
+
+import ormsgpack
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+
+ROOT = Path(__file__).resolve().parent
+FISH_SPEECH_DIR = Path(os.getenv("FISH_SPEECH_DIR", ROOT / "fish-speech")).resolve()
+MODEL_DIR = Path(
+    os.getenv(
+        "FISH_S2_MODEL_DIR",
+        FISH_SPEECH_DIR / "checkpoints" / "fish-speech-s2-pro-int8",
+    )
+).resolve()
+
+HOST = os.getenv("TOMORI_TTS_HOST", "127.0.0.1")
+PORT = int(os.getenv("TOMORI_TTS_PORT", "8015"))
+UPSTREAM_HOST = os.getenv("FISH_S2_UPSTREAM_HOST", "127.0.0.1")
+UPSTREAM_PORT = int(os.getenv("FISH_S2_UPSTREAM_PORT", "8025"))
+UPSTREAM_URL = f"http://{UPSTREAM_HOST}:{UPSTREAM_PORT}"
+MAX_TEXT_CHARS = int(os.getenv("TOMORI_TTS_MAX_TEXT_CHARS", "2000"))
+STARTUP_TIMEOUT_SECONDS = float(os.getenv("FISH_S2_STARTUP_TIMEOUT_SECONDS", "180"))
+COMPILE = os.getenv("FISH_S2_COMPILE", "0").lower() in {"1", "true", "yes", "on"}
+HALF = os.getenv("FISH_S2_HALF", "0").lower() in {"1", "true", "yes", "on"}
+
+CHUNK_LENGTH = int(os.getenv("FISH_S2_CHUNK_LENGTH", "200"))
+TOP_P = float(os.getenv("FISH_S2_TOP_P", "0.8"))
+TEMPERATURE = float(os.getenv("FISH_S2_TEMPERATURE", "0.8"))
+REPETITION_PENALTY = float(os.getenv("FISH_S2_REPETITION_PENALTY", "1.1"))
+MAX_NEW_TOKENS = int(os.getenv("FISH_S2_MAX_NEW_TOKENS", "1024"))
+USE_MEMORY_CACHE = os.getenv("FISH_S2_USE_MEMORY_CACHE", "on")
+
+fish_process: subprocess.Popen[bytes] | None = None
+
+
+class SynthesizeRequest(BaseModel):
+    text: str
+    ref_audio: str
+    ref_text: Optional[str] = None
+    instruct: Optional[str] = None
+    language: Optional[str] = None
+
+
+def require_installation() -> None:
+    api_server = FISH_SPEECH_DIR / "tools" / "api_server.py"
+    codec = MODEL_DIR / "codec.pth"
+    if not api_server.is_file():
+        raise RuntimeError(
+            f"Fish Speech runtime not found at {FISH_SPEECH_DIR}. "
+            "Run the Fish S2 setup instructions first."
+        )
+    if not codec.is_file():
+        raise RuntimeError(
+            f"Fish S2 Pro checkpoint not found at {MODEL_DIR}. "
+            "Download Imagilux/fishaudio-s2-pro before starting the sidecar."
+        )
+
+
+def wait_for_upstream() -> None:
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    health_url = f"{UPSTREAM_URL}/v1/health"
+    while time.monotonic() < deadline:
+        if fish_process is not None and fish_process.poll() is not None:
+            raise RuntimeError(f"Fish Speech API exited during startup with code {fish_process.returncode}.")
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as response:
+                if 200 <= response.status < 300:
+                    return
+        except (urllib.error.URLError, TimeoutError):
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"Fish Speech API did not become ready within {STARTUP_TIMEOUT_SECONDS:.0f}s.")
+
+
+def start_fish_api() -> None:
+    global fish_process
+    require_installation()
+
+    command = [
+        sys.executable,
+        str(FISH_SPEECH_DIR / "tools" / "api_server.py"),
+        "--llama-checkpoint-path",
+        str(MODEL_DIR),
+        "--decoder-checkpoint-path",
+        str(MODEL_DIR / "codec.pth"),
+        "--listen",
+        f"{UPSTREAM_HOST}:{UPSTREAM_PORT}",
+        "--workers",
+        "1",
+    ]
+    if COMPILE:
+        command.append("--compile")
+    if HALF:
+        command.append("--half")
+
+    fish_process = subprocess.Popen(command, cwd=FISH_SPEECH_DIR)
+    wait_for_upstream()
+
+
+def stop_fish_api() -> None:
+    global fish_process
+    if fish_process is None or fish_process.poll() is not None:
+        return
+    fish_process.terminate()
+    try:
+        fish_process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        fish_process.kill()
+        fish_process.wait(timeout=5)
+    fish_process = None
+
+
+atexit.register(stop_fish_api)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    start_fish_api()
+    try:
+        yield
+    finally:
+        stop_fish_api()
+
+
+app = FastAPI(title="TomoriBot Fish Audio S2 Pro TTS Server", lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict[str, str | bool]:
+    running = fish_process is not None and fish_process.poll() is None
+    return {
+        "status": "ok" if running else "loading",
+        "model": "fish-audio-s2-pro-int8",
+        "model_dir": str(MODEL_DIR),
+        "runtime": "Imagilux/fish-speech",
+        "compile": COMPILE,
+        "half": HALF,
+        "supports_bracket_tags": True,
+    }
+
+
+def decode_reference_audio(raw_base64: str) -> bytes:
+    try:
+        audio = base64.b64decode(raw_base64, validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="ref_audio must be valid base64.") from exc
+    if not audio:
+        raise HTTPException(status_code=400, detail="ref_audio must not be empty.")
+    return audio
+
+
+@app.post("/synthesize")
+def synthesize(payload: SynthesizeRequest) -> Response:
+    if fish_process is None or fish_process.poll() is not None:
+        raise HTTPException(status_code=503, detail="Fish Speech runtime is not ready.")
+
+    text = payload.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text is required.")
+    if len(text) > MAX_TEXT_CHARS:
+        raise HTTPException(status_code=400, detail=f"text exceeds {MAX_TEXT_CHARS} characters.")
+    if not payload.ref_audio.strip():
+        raise HTTPException(status_code=400, detail="ref_audio is required for Fish S2 Pro voice cloning.")
+
+    reference_audio = decode_reference_audio(payload.ref_audio)
+    reference_text = payload.ref_text.strip() if payload.ref_text else ""
+
+    request_data = {
+        "text": text,
+        "references": [{"audio": reference_audio, "text": reference_text}],
+        "reference_id": None,
+        "format": "wav",
+        "latency": "normal",
+        "max_new_tokens": MAX_NEW_TOKENS,
+        "chunk_length": CHUNK_LENGTH,
+        "top_p": TOP_P,
+        "repetition_penalty": REPETITION_PENALTY,
+        "temperature": TEMPERATURE,
+        "streaming": False,
+        "use_memory_cache": USE_MEMORY_CACHE,
+        "seed": None,
+    }
+
+    packed = ormsgpack.packb(request_data)
+    request = urllib.request.Request(
+        f"{UPSTREAM_URL}/v1/tts?format=msgpack",
+        data=packed,
+        headers={"Content-Type": "application/msgpack"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=240) as response:
+            audio = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise HTTPException(status_code=502, detail=f"Fish Speech synthesis failed: {detail}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise HTTPException(status_code=502, detail=f"Fish Speech runtime unavailable: {exc}") from exc
+
+    if not audio:
+        raise HTTPException(status_code=502, detail="Fish Speech returned an empty audio response.")
+    return Response(content=audio, media_type="audio/wav")
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT)

--- a/servers/tts/fishs2/server.py
+++ b/servers/tts/fishs2/server.py
@@ -2,19 +2,24 @@ from __future__ import annotations
 
 import atexit
 import base64
+import binascii
+import hmac
+import io
+import ipaddress
 import os
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+import wave
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional
 
 import ormsgpack
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -29,14 +34,26 @@ MODEL_DIR = Path(
 ).resolve()
 
 HOST = os.getenv("TOMORI_TTS_HOST", "127.0.0.1")
-PORT = int(os.getenv("TOMORI_TTS_PORT", "8015"))
+PORT = int(os.getenv("FISH_S2_PORT", os.getenv("TOMORI_TTS_PORT", "8015")))
 UPSTREAM_HOST = os.getenv("FISH_S2_UPSTREAM_HOST", "127.0.0.1")
 UPSTREAM_PORT = int(os.getenv("FISH_S2_UPSTREAM_PORT", "8025"))
 UPSTREAM_URL = f"http://{UPSTREAM_HOST}:{UPSTREAM_PORT}"
 MAX_TEXT_CHARS = int(os.getenv("TOMORI_TTS_MAX_TEXT_CHARS", "2000"))
+MAX_REFERENCE_AUDIO_BYTES = int(
+    os.getenv("FISH_S2_MAX_REF_AUDIO_BYTES", os.getenv("TOMORI_TTS_MAX_REF_AUDIO_BYTES", str(10 * 1024 * 1024)))
+)
 STARTUP_TIMEOUT_SECONDS = float(os.getenv("FISH_S2_STARTUP_TIMEOUT_SECONDS", "180"))
+SYNTHESIS_TIMEOUT_SECONDS = float(os.getenv("FISH_S2_SYNTHESIS_TIMEOUT_SECONDS", "240"))
 COMPILE = os.getenv("FISH_S2_COMPILE", "0").lower() in {"1", "true", "yes", "on"}
 HALF = os.getenv("FISH_S2_HALF", "0").lower() in {"1", "true", "yes", "on"}
+MODEL_ID = os.getenv("FISH_S2_MODEL_ID", "Imagilux/fishaudio-s2-pro")
+API_KEY = (os.getenv("FISH_S2_API_KEY") or os.getenv("TOMORI_TTS_API_KEY") or "").strip()
+ALLOW_INSECURE_REMOTE = os.getenv("FISH_S2_ALLOW_INSECURE_REMOTE", "0").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 CHUNK_LENGTH = int(os.getenv("FISH_S2_CHUNK_LENGTH", "200"))
 TOP_P = float(os.getenv("FISH_S2_TOP_P", "0.8"))
@@ -56,6 +73,37 @@ class SynthesizeRequest(BaseModel):
     language: Optional[str] = None
 
 
+def is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_bind_policy() -> None:
+    if not is_loopback_host(HOST) and not API_KEY and not ALLOW_INSECURE_REMOTE:
+        raise RuntimeError(
+            "Fish S2 remote binding requires FISH_S2_API_KEY or "
+            "FISH_S2_ALLOW_INSECURE_REMOTE=1. Keep TOMORI_TTS_HOST on loopback when possible."
+        )
+
+
+def authorize_request(request: Request | None) -> None:
+    if not API_KEY:
+        return
+    authorization = request.headers.get("authorization", "") if request is not None else ""
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not hmac.compare_digest(token, API_KEY):
+        raise HTTPException(
+            status_code=401,
+            detail="A valid bearer token is required.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
 def require_installation() -> None:
     api_server = FISH_SPEECH_DIR / "tools" / "api_server.py"
     codec = MODEL_DIR / "codec.pth"
@@ -67,7 +115,7 @@ def require_installation() -> None:
     if not codec.is_file():
         raise RuntimeError(
             f"Fish S2 Pro checkpoint not found at {MODEL_DIR}. "
-            "Download Imagilux/fishaudio-s2-pro before starting the sidecar."
+            f"Download {MODEL_ID} before starting the sidecar."
         )
 
 
@@ -89,6 +137,7 @@ def wait_for_upstream() -> None:
 
 def start_fish_api() -> None:
     global fish_process
+    validate_bind_policy()
     require_installation()
 
     command = [
@@ -141,11 +190,13 @@ app = FastAPI(title="TomoriBot Fish Audio S2 Pro TTS Server", lifespan=lifespan)
 
 
 @app.get("/health")
-def health() -> dict[str, str | bool]:
+def health(request: Request) -> dict[str, str | bool]:
+    authorize_request(request)
     running = fish_process is not None and fish_process.poll() is None
     return {
         "status": "ok" if running else "loading",
-        "model": "fish-audio-s2-pro-int8",
+        "model": MODEL_ID,
+        "model_family": "Fish Audio S2 Pro",
         "model_dir": str(MODEL_DIR),
         "runtime": "Imagilux/fish-speech",
         "compile": COMPILE,
@@ -154,18 +205,56 @@ def health() -> dict[str, str | bool]:
     }
 
 
+def validate_wav_container(audio: bytes) -> None:
+    if len(audio) < 12 or audio[:4] != b"RIFF" or audio[8:12] != b"WAVE":
+        raise HTTPException(status_code=400, detail="ref_audio must be a RIFF/WAVE container.")
+
+    declared_size = int.from_bytes(audio[4:8], "little") + 8
+    if declared_size > len(audio):
+        raise HTTPException(status_code=400, detail="ref_audio contains a truncated WAV container.")
+
+    try:
+        with wave.open(io.BytesIO(audio), "rb") as wav_file:
+            if wav_file.getcomptype() != "NONE":
+                raise HTTPException(status_code=400, detail="ref_audio must contain uncompressed PCM audio.")
+            if wav_file.getnchannels() < 1 or wav_file.getframerate() < 1 or wav_file.getsampwidth() < 1:
+                raise HTTPException(status_code=400, detail="ref_audio has invalid WAV audio parameters.")
+            if wav_file.getnframes() < 1:
+                raise HTTPException(status_code=400, detail="ref_audio must contain at least one audio frame.")
+            expected_bytes = wav_file.getnframes() * wav_file.getnchannels() * wav_file.getsampwidth()
+            if len(wav_file.readframes(wav_file.getnframes())) < expected_bytes:
+                raise HTTPException(status_code=400, detail="ref_audio contains truncated PCM data.")
+    except HTTPException:
+        raise
+    except (EOFError, OSError, ValueError, wave.Error) as exc:
+        raise HTTPException(status_code=400, detail="ref_audio is not a valid PCM WAV file.") from exc
+
+
 def decode_reference_audio(raw_base64: str) -> bytes:
+    max_encoded_length = ((MAX_REFERENCE_AUDIO_BYTES + 2) // 3) * 4
+    if len(raw_base64) > max_encoded_length:
+        raise HTTPException(
+            status_code=413,
+            detail=f"ref_audio exceeds the {MAX_REFERENCE_AUDIO_BYTES} byte limit.",
+        )
     try:
         audio = base64.b64decode(raw_base64, validate=True)
-    except Exception as exc:
+    except (binascii.Error, ValueError) as exc:
         raise HTTPException(status_code=400, detail="ref_audio must be valid base64.") from exc
     if not audio:
         raise HTTPException(status_code=400, detail="ref_audio must not be empty.")
+    if len(audio) > MAX_REFERENCE_AUDIO_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"ref_audio exceeds the {MAX_REFERENCE_AUDIO_BYTES} byte limit.",
+        )
+    validate_wav_container(audio)
     return audio
 
 
 @app.post("/synthesize")
-def synthesize(payload: SynthesizeRequest) -> Response:
+def synthesize(payload: SynthesizeRequest, request: Request) -> Response:
+    authorize_request(request)
     if fish_process is None or fish_process.poll() is not None:
         raise HTTPException(status_code=503, detail="Fish Speech runtime is not ready.")
 
@@ -205,7 +294,7 @@ def synthesize(payload: SynthesizeRequest) -> Response:
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=240) as response:
+        with urllib.request.urlopen(request, timeout=SYNTHESIS_TIMEOUT_SECONDS) as response:
             audio = response.read()
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")

--- a/servers/tts/fishs2/test_server.py
+++ b/servers/tts/fishs2/test_server.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import base64
+import io
+import unittest
+import wave
+from unittest.mock import patch
+
+import ormsgpack
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+import server
+
+
+class RunningProcess:
+    returncode = None
+
+    def poll(self) -> None:
+        return None
+
+
+class UpstreamResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def __enter__(self) -> "UpstreamResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.content
+
+
+def request_with_headers(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/health",
+            "headers": headers or [],
+            "query_string": b"",
+            "server": ("127.0.0.1", 8015),
+            "client": ("127.0.0.1", 50000),
+            "scheme": "http",
+        }
+    )
+
+
+def pcm_wav() -> bytes:
+    output = io.BytesIO()
+    with wave.open(output, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(b"\x00\x00" * 160)
+    return output.getvalue()
+
+
+class FishServerContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_process = server.fish_process
+        self.original_api_key = server.API_KEY
+        server.fish_process = RunningProcess()
+        server.API_KEY = ""
+
+    def tearDown(self) -> None:
+        server.fish_process = self.original_process
+        server.API_KEY = self.original_api_key
+
+    def test_health_reports_configured_model_metadata(self) -> None:
+        result = server.health(request_with_headers())
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["model_family"], "Fish Audio S2 Pro")
+        self.assertIn("model_dir", result)
+
+    def test_bearer_auth_is_required_when_configured(self) -> None:
+        server.API_KEY = "test-token"
+
+        with self.assertRaises(HTTPException) as context:
+            server.health(request_with_headers())
+        self.assertEqual(context.exception.status_code, 401)
+
+        result = server.health(request_with_headers([(b"authorization", b"Bearer test-token")]))
+        self.assertEqual(result["status"], "ok")
+
+    def test_reference_audio_requires_pcm_wav(self) -> None:
+        with self.assertRaises(HTTPException) as context:
+            server.decode_reference_audio(base64.b64encode(b"not-a-wav").decode("ascii"))
+        self.assertEqual(context.exception.status_code, 400)
+
+    def test_reference_audio_limit_is_checked_before_inference(self) -> None:
+        original_limit = server.MAX_REFERENCE_AUDIO_BYTES
+        server.MAX_REFERENCE_AUDIO_BYTES = 4
+        try:
+            with self.assertRaises(HTTPException) as context:
+                server.decode_reference_audio(base64.b64encode(b"12345").decode("ascii"))
+            self.assertEqual(context.exception.status_code, 413)
+        finally:
+            server.MAX_REFERENCE_AUDIO_BYTES = original_limit
+
+    def test_synthesize_builds_fish_msgpack_request(self) -> None:
+        reference = pcm_wav()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(request: object, timeout: float) -> UpstreamResponse:
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return UpstreamResponse(b"generated-audio")
+
+        payload = server.SynthesizeRequest(
+            text="Hello",
+            ref_audio=base64.b64encode(reference).decode("ascii"),
+            ref_text="Hello there",
+        )
+        with patch("server.urllib.request.urlopen", side_effect=fake_urlopen):
+            response = server.synthesize(payload, request_with_headers())
+
+        self.assertEqual(response.media_type, "audio/wav")
+        self.assertEqual(response.body, b"generated-audio")
+        upstream_request = captured["request"]
+        self.assertIsInstance(upstream_request, server.urllib.request.Request)
+        body = ormsgpack.unpackb(upstream_request.data)
+        self.assertEqual(body["text"], "Hello")
+        self.assertEqual(body["references"][0]["audio"], reference)
+        self.assertEqual(body["references"][0]["text"], "Hello there")
+
+    def test_fastapi_routes_expose_health_and_synthesize_contract(self) -> None:
+        reference = pcm_wav()
+        with patch("server.start_fish_api"), patch("server.stop_fish_api"), patch(
+            "server.urllib.request.urlopen", return_value=UpstreamResponse(b"generated-audio")
+        ):
+            with TestClient(server.app) as client:
+                health_response = client.get("/health")
+                synthesis_response = client.post(
+                    "/synthesize",
+                    json={
+                        "text": "Hello",
+                        "ref_audio": base64.b64encode(reference).decode("ascii"),
+                        "ref_text": "Hello there",
+                    },
+                )
+
+        self.assertEqual(health_response.status_code, 200)
+        self.assertEqual(health_response.json()["status"], "ok")
+        self.assertEqual(synthesis_response.status_code, 200)
+        self.assertEqual(synthesis_response.headers["content-type"], "audio/wav")
+        self.assertEqual(synthesis_response.content, b"generated-audio")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Fish Audio S2 Pro as a new self-hosted TTS sidecar for TomoriBot.

- Adds a `servers/tts/fishs2/` wrapper that preserves TomoriBot's existing `POST /synthesize` contract and proxies requests into Fish Speech's local MessagePack API.
- Forwards both reference audio and the stored reference transcript for voice cloning.
- Preserves Fish S2 Pro bracket expression controls such as `[whisper]`, `[excited]`, and `[angry]` through TomoriBot's existing `Bracket Tags` markup mode.
- Defaults setup to `Imagilux/fishaudio-s2-pro`, an INT8 weight-only S2 Pro checkpoint intended to fit consumer GPUs with at least 16 GB VRAM while retaining BF16 embeddings, layer norms, and codec.
- Adds Linux/WSL and best-effort native Windows installers that clone the Imagilux Fish Speech runtime and download the gated Hugging Face checkpoint.
- Adds `bun run launch --fishs2` support.
- Adds full English setup, hardware, licensing, endpoint-registration, persona-voice, expression-control, and environment-variable documentation.

## Base branch

This PR intentionally targets `refactor/command-modernization` so it inherits the current `/providers`, `/config`, and `/generate voice-message` command flow.

## Notes

- Fish Audio S2 Pro and the quantized checkpoint remain subject to the Fish Audio Research License. TomoriBot does not redistribute the weights; self-hosters download them directly from Hugging Face.
- Fish Audio officially documents Linux/WSL for local S2 inference. The PowerShell installer is provided as best-effort native Windows support.
- The official BF16 S2 Pro setup recommends 24 GB+ VRAM. The default INT8 checkpoint is used specifically to make the sidecar practical on 16 GB consumer GPUs.
