### PR TITLE
Add VoxCPM2 TTS support

### DIFF
--- a/.env.optional.example
+++ b/.env.optional.example
@@ -359,6 +359,8 @@ SPEECH_SAMPLE_MAX_MB=10
 # Timeout in milliseconds for /synthesize requests to local TTS clone and VoiceDesign servers (default: 240000).
 # Increase this if large models (e.g. Qwen3-TTS 1.7B on CPU) time out before finishing generation.
 TTS_SYNTHESIZE_TIMEOUT_MS=240000
+# Maximum time in milliseconds for `bun run launch --<python-sidecar>` to observe a ready JSON health status.
+#TOMORI_TTS_STARTUP_TIMEOUT_MS=300000
 # Backward-compatible legacy name. Used only when TTS_SYNTHESIZE_TIMEOUT_MS is unset.
 #TTS_CLONE_TIMEOUT_MS=240000
 # Irodori-TTS sidecar model ID (default: Aratako/Irodori-TTS-v4.1-Small).
@@ -366,6 +368,14 @@ TTS_SYNTHESIZE_TIMEOUT_MS=240000
 #IRODORI_TTS_MODEL_ID=Aratako/Irodori-TTS-v4.1-Small
 # Local checkpoint file path for Irodori-TTS. Overrides IRODORI_TTS_MODEL_ID when set (default: unset).
 #IRODORI_TTS_CHECKPOINT=
+# VoxCPM2 local sidecar settings (see docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md).
+#VOXCPM2_PORT=8016
+#VOXCPM2_MAX_REF_AUDIO_BYTES=10485760
+#VOXCPM2_API_KEY=
+# Shared fallback accepted by the VoxCPM2 wrapper when its engine-specific key is unset.
+#TOMORI_TTS_API_KEY=
+# Keep local wrappers on loopback by default. Set to true only for an intentional remote bind.
+#TOMORI_TTS_ALLOW_REMOTE_BIND=false
 
 # Maximum tool names retained from the latest successful remote discovery (default: 100)
 MCP_TOOL_SNAPSHOT_MAX_NAMES=100

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -44,6 +44,34 @@ jobs:
         with:
           bun-version: 1.4.0
 
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.11"
+
+      - name: Validate Python sidecar contracts and installer syntax
+        shell: bash
+        run: |
+          python -m pip install --disable-pip-version-check --quiet -r servers/tts/voxcpm2/requirements-test.txt
+          python -m py_compile servers/tts/voxcpm2/server.py servers/tts/voxcpm2/test_server.py
+          python -m unittest discover -s servers/tts/voxcpm2 -p 'test_*.py'
+          while IFS= read -r installer; do bash -n "$installer"; done < <(find servers -type f -name 'install-*.sh' -print)
+
+      - name: Validate PowerShell installer syntax
+        shell: pwsh
+        run: |
+          $parseErrors = @()
+          Get-ChildItem -Path servers -Filter 'install-*.ps1' -Recurse | ForEach-Object {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+            $parseErrors += $errors
+          }
+          if ($parseErrors.Count -gt 0) {
+            $parseErrors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
       - name: Install PostgreSQL client tools
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Docker Compose builds and runs TomoriBot plus PostgreSQL. It does not use the se
 For Docker Compose, start from `.env.example`, then add `POSTGRES_PASSWORD` if you have not already set it. Optional Docker or runtime tuning values can still be copied from `.env.optional.example`.
 
 ```sh
-# Build and start TomoriBot and her database
+# Build and start TomoriBot plus PostgreSQL
 docker compose up --build
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ bun run update
 The command runs this sequence, stopping immediately if any step fails:
 
 1. **`bun run backup`** - takes a full database backup into `/backups/` *before* touching any code. If the backup fails, the update aborts with your deployment completely unchanged.
-2. **`git pull --rebase --autostash`
-3. **`bun install --frozen-lockfile`
+2. **`git pull --rebase --autostash`**
+3. **`bun install --frozen-lockfile`**
 
 Then restart TomoriBot with `bun run dev` or `bun run launch`
 

--- a/README.md
+++ b/README.md
@@ -201,12 +201,13 @@ bun run launch --searxng --crawl4ai
 
 # With a local TTS server after following the voice setup docs
 bun run launch --qwen3tts
+bun run launch --voxcpm2
 
 # See all available flags
 bun run launch --help
 ```
 
-Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--whisperx`, `--help`
+Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--voxcpm2`, `--whisperx`, `--help`
 
 **Ctrl+C** stops the bot and any Python sidecar processes. Docker containers (`--searxng`, `--crawl4ai`) are intentionally left running, stop them manually with `docker stop searxng` / `docker stop crawl4ai` when you're done.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Docker Compose builds and runs TomoriBot plus PostgreSQL. It does not use the se
 For Docker Compose, start from `.env.example`, then add `POSTGRES_PASSWORD` if you have not already set it. Optional Docker or runtime tuning values can still be copied from `.env.optional.example`.
 
 ```sh
-# Build and start TomoriBot plus PostgreSQL
+# Build and start TomoriBot and her database
 docker compose up --build
 ```
 
@@ -241,8 +241,8 @@ bun run update
 The command runs this sequence, stopping immediately if any step fails:
 
 1. **`bun run backup`** - takes a full database backup into `/backups/` *before* touching any code. If the backup fails, the update aborts with your deployment completely unchanged.
-2. **`git pull --rebase --autostash`**
-3. **`bun install --frozen-lockfile`**
+2. **`git pull --rebase --autostash`
+3. **`bun install --frozen-lockfile`
 
 Then restart TomoriBot with `bun run dev` or `bun run launch`
 

--- a/docs/en/self-hosting/local-endpoints/README.mdx
+++ b/docs/en/self-hosting/local-endpoints/README.mdx
@@ -34,7 +34,7 @@ Pick a capability to set up:
 
 <CardGrid>
   <LinkCard title="Text-to-Speech" href="/self-hosting/local-endpoints/text-to-speech/"
-    description="Local TTS engines (Chatterbox, Qwen3-TTS, IrodoriTTS) for native Discord voice messages with voice cloning." />
+    description="Local TTS engines (Chatterbox, Qwen3-TTS, IrodoriTTS, VoxCPM2) for native Discord voice messages, voice cloning, and VoiceDesign." />
   <LinkCard title="Speech-to-Text" href="/self-hosting/local-endpoints/speech-to-text/"
     description="Transcribe audio attachments locally with WhisperX, whisper.cpp, or KoboldCPP." />
 </CardGrid>
@@ -68,12 +68,13 @@ bun run launch --searxng --crawl4ai
 
 # With a local TTS server (venv must be set up first — see the Text-to-Speech guide below)
 bun run launch --qwen3tts
+bun run launch --voxcpm2
 
 # See all available flags
 bun run launch --help
 ```
 
-Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--whisperx`
+Available flags: `--searxng`, `--crawl4ai`, `--qwen3tts`, `--chatterbox`, `--irodoritts`, `--voxcpm2`, `--whisperx`
 
 Docker sidecars (`--searxng`, `--crawl4ai`) are created on first run and reused on subsequent runs. Python TTS/STT sidecars require their venv to be set up once beforehand; see the individual setup guides under [Text-to-Speech](/self-hosting/local-endpoints/text-to-speech/) and [Speech-to-Text](/self-hosting/local-endpoints/speech-to-text/).
 

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/README.mdx
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/README.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-TomoriBot treats speech as a custom endpoint capability. Local engines run outside the bot as HTTP servers and implement `POST /synthesize`; most clone engines receive text plus the configured reference audio sample.
+TomoriBot treats speech as a custom endpoint capability. Local engines run outside the bot as HTTP servers and implement `POST /synthesize`; clone engines receive text plus the configured reference audio sample, while VoiceDesign-capable engines can also receive natural-language instructions.
 
 ## Available Engines
 
@@ -17,18 +17,19 @@ TomoriBot treats speech as a custom endpoint capability. Local engines run outsi
   <LinkCard title="Chatterbox TTS" href="/self-hosting/local-endpoints/text-to-speech/chatterbox/"
     description="Fast local voice cloning through Chatterbox-Turbo, with supported bracket delivery tags for expressive speech." />
   <LinkCard title="Qwen3-TTS" href="/self-hosting/local-endpoints/text-to-speech/qwen3tts/"
-    description="Multilingual local TTS with clone and VoiceDesign modes. Largest but best quality." />
+    description="Multilingual local TTS with clone and VoiceDesign modes." />
   <LinkCard title="IrodoriTTS" href="/self-hosting/local-endpoints/text-to-speech/irodoritts/"
-    description="Japanese-focused voice cloning that preserves Unicode emoji markup for emotion control." />
+    description="Japanese-focused voice cloning and VoiceDesign with Unicode emoji markup for emotion control." />
+  <LinkCard title="VoxCPM2" href="/self-hosting/local-endpoints/text-to-speech/voxcpm2/"
+    description="30-language TTS with Voice Design, reference-audio cloning, transcript-assisted Ultimate Cloning, and natural-language delivery control." />
 </CardGrid>
 
 ## Setup Flow
 
-1. Pick one engine from the cards above and start its wrapper from `servers/tts/`.
+1. Pick one engine from the cards above and set up its wrapper from `servers/tts/`.
 2. In `/providers`, choose **Add New Custom Endpoint** and use API Compatibility `tts-clone`.
-3. Select the saved endpoint and use its model dropdown to add its exact model code.
-
-Use `/providers` for endpoint registration and model setup. Then open `/config` > Models > Switch Models to select and activate the registered endpoint.
+3. Select the saved endpoint and use its model dropdown to add its Speech model, Voice Source Mode, and Script Markup.
+4. Open `/config` > Models > Switch Models and select the registered Speech model.
 
 ## Persona Voice Flow
 
@@ -36,27 +37,26 @@ For clone engines, add and assign one voice sample per persona:
 
 1. Prepare a clean 10-20 second clip with one speaker and no background music.
 2. Open `/config` under Models > TTS Parameters & Voices and upload the sample. Any audio format is accepted; TomoriBot converts it to mono WAV.
-3. Open `/config` under Persona > Voice, then choose the persona and voice sample.
+3. Provide a matching transcript when the engine benefits from it. VoxCPM2 uses the stored transcript for its higher-fidelity Ultimate Cloning mode.
+4. Open `/config` under Persona > Voice, then choose the persona and voice sample.
 
-For Qwen3-TTS VoiceDesign, skip the audio sample and use Persona > Voice in `/config` for each persona instead.
+For Qwen3-TTS, IrodoriTTS, or VoxCPM2 VoiceDesign, skip the audio sample and use Persona > Voice in `/config` to save a natural-language voice description for the persona.
 
 ElevenLabs users should choose **Add New Provider** and **ElevenLabs** in `/providers`; it registers the speech and transcription endpoints together.
 
-TomoriBot strips Discord custom emoji syntax such as `:pepega:` or `<:pepega:123456789012345678>` from generated voice scripts before synthesis. Unicode emojis are also stripped unless the speech endpoint uses emoji markup, which is intended for IrodoriTTS.
+TomoriBot strips Discord custom emoji syntax such as `:pepega:` or `<:pepega:123456789012345678>` from generated voice scripts before synthesis. Unicode emojis are also stripped unless the speech endpoint uses emoji markup, which is intended for IrodoriTTS. Bracket tags are preserved for endpoints such as Chatterbox Turbo when Script Markup is set to **Bracket Tags**.
+
+VoxCPM2 uses **Plain** Script Markup. Its Voice Design and speaking-style controls travel through TomoriBot's `instruct` field, and the VoxCPM2 wrapper converts them to the model's native parenthesized natural-language control syntax.
 
 ## Hardware requirements
 
-Local TTS engines are **much lighter than an LLM** — these are small models (roughly
-0.5B–1.7B parameters). Even a modest NVIDIA GPU (a few GB of VRAM is plenty) runs any of them
-comfortably and keeps synthesis fast. They also run on **CPU** — slower, but workable, since
-voice clips are short.
+Hardware requirements differ by engine, but all current reference sidecars are practical on consumer hardware. CPU operation is possible for several engines but is much slower than GPU inference.
 
 | Engine | Model size | Notes |
 |---|---|---|
-| Chatterbox | ~0.5B (Turbo) | Fastest current option. |
+| Chatterbox | ~0.5B (Turbo) | Fast local option with bracket delivery tags. |
 | Qwen3-TTS | 1.7B (12 Hz) | Separate clone + VoiceDesign models; only one loads at a time. |
-| IrodoriTTS | 500M (v2) | Japanese-focused; `bf16` on GPU, `fp32` on CPU. |
+| IrodoriTTS | ~0.5B | Japanese-focused clone + VoiceDesign. |
+| VoxCPM2 | 2B | Official BF16 runtime is about 8 GB VRAM; 16 GB consumer NVIDIA GPUs have ample headroom. |
 
-The first synthesis after startup (or after Qwen3-TTS swaps models in auto mode) is slower
-while the model loads into memory; later requests are fast. TomoriBot waits up to
-`TTS_SYNTHESIZE_TIMEOUT_MS` (default 240000 ms) for each response.
+The first synthesis after startup (or after Qwen3-TTS swaps models in auto mode) is slower while the model loads and warms up. TomoriBot waits up to `TTS_SYNTHESIZE_TIMEOUT_MS` (default 240000 ms) for each response.

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
@@ -1,0 +1,167 @@
+---
+title: "VoxCPM2"
+aiGenerated: false
+---
+
+VoxCPM2 is OpenBMB's 2B-parameter multilingual text-to-speech model. It supports 30 languages, 48 kHz output, natural-language Voice Design, reference-audio voice cloning, controllable cloning, and transcript-assisted "Ultimate Cloning". TomoriBot uses the official `voxcpm` Python package through the thin wrapper in `servers/tts/voxcpm2/`.
+
+The default model is the official `openbmb/VoxCPM2` BF16 checkpoint. OpenBMB reports roughly **8 GB VRAM** for the standard runtime, so the normal model comfortably fits a 16 GB NVIDIA GPU and no quantized checkpoint is needed by default.
+
+## License
+
+VoxCPM2 code and model weights are released under **Apache-2.0**, including commercial use subject to the license terms. TomoriBot does not redistribute the weights; the installer downloads them from the official Hugging Face repository.
+
+Official upstream resources:
+
+- [OpenBMB/VoxCPM](https://github.com/OpenBMB/VoxCPM)
+- [openbmb/VoxCPM2 on Hugging Face](https://huggingface.co/openbmb/VoxCPM2)
+- [VoxCPM documentation](https://voxcpm.readthedocs.io/)
+
+## Supported languages
+
+VoxCPM2 officially supports 30 languages without requiring a language tag:
+
+Arabic, Burmese, Chinese, Danish, Dutch, English, Finnish, French, German, Greek, Hebrew, Hindi, Indonesian, Italian, Japanese, Khmer, Korean, Lao, Malay, Norwegian, Polish, Portuguese, Russian, Spanish, Swahili, Swedish, Tagalog, Thai, Turkish, and Vietnamese.
+
+OpenBMB also documents several Chinese dialects. TomoriBot may still send a `language` field for compatibility with the common TTS contract, but VoxCPM2 detects the language from the synthesis text and the wrapper does not force a language tag.
+
+## Voice modes
+
+One VoxCPM2 endpoint can handle all useful TomoriBot voice-source modes:
+
+| TomoriBot request | VoxCPM2 behavior |
+|---|---|
+| `text` only | Normal zero-shot synthesis |
+| `text` + `instruct` | Voice Design from a natural-language description |
+| `text` + `ref_audio` | Reference-audio voice cloning |
+| `text` + `ref_audio` + `instruct` | Controllable cloning: preserve the speaker while steering delivery |
+| `text` + `ref_audio` + `ref_text` | Ultimate Cloning using the reference audio and its transcript |
+| `text` + `ref_audio` + `ref_text` + `instruct` | Transcript-assisted cloning plus natural-language delivery control |
+
+VoxCPM2 represents Voice Design and style control by placing a natural-language description in parentheses before the text to synthesize. TomoriBot already has an `instruct` field for this purpose, so the wrapper performs that conversion automatically.
+
+Use **Plain** Script Markup. VoxCPM2 does not require TomoriBot to preserve bracket tags or emoji control syntax, and no new Script Markup mode is necessary.
+
+## Hardware and runtime
+
+Recommended starting point:
+
+- Python **3.10-3.12**
+- NVIDIA GPU with **8 GB VRAM or more** for the official BF16 runtime; 12-16 GB gives comfortable headroom
+- Current NVIDIA driver and a CUDA-enabled PyTorch build for GPU acceleration
+- CPU is supported but substantially slower
+
+The official package also exposes CPU and Apple MPS device selection. For TomoriBot on Windows, the standard Python package can run natively; WSL is not required. If your native Windows PyTorch installation does not detect CUDA, install a CUDA-enabled PyTorch build that matches your driver from the official PyTorch instructions.
+
+OpenBMB reports about 0.30 RTF on an RTX 4090 with the standard runtime. Upstream also supports streaming generation and documents faster Nano-vLLM and vLLM-Omni serving options. TomoriBot's current `POST /synthesize` contract returns one WAV response, so this sidecar intentionally buffers the generated utterance instead of exposing a separate streaming protocol.
+
+## Installation
+
+The sidecar pins the current stable `voxcpm` 2.0.3 package and downloads `openbmb/VoxCPM2` into the normal Hugging Face cache.
+
+### Linux / WSL Bash
+
+From the TomoriBot repository root:
+
+```bash
+bash servers/tts/voxcpm2/install-voxcpm2.sh
+servers/tts/voxcpm2/.venv/bin/python servers/tts/voxcpm2/server.py
+```
+
+### Windows PowerShell
+
+From the TomoriBot repository root:
+
+```powershell
+.\servers\tts\voxcpm2\install-voxcpm2.ps1
+.\servers\tts\voxcpm2\.venv\Scripts\python.exe servers\tts\voxcpm2\server.py
+```
+
+The first setup downloads several gigabytes of model weights. To install the Python environment without prefetching the model, set `VOXCPM2_PREFETCH=0`; the official library will then download the checkpoint on first server start.
+
+Linux / WSL:
+
+```bash
+VOXCPM2_PREFETCH=0 bash servers/tts/voxcpm2/install-voxcpm2.sh
+```
+
+PowerShell:
+
+```powershell
+$env:VOXCPM2_PREFETCH = "0"
+.\servers\tts\voxcpm2\install-voxcpm2.ps1
+```
+
+After setup, `bun run launch --voxcpm2` starts the sidecar together with TomoriBot. The default endpoint is `http://127.0.0.1:8016`.
+
+## Register in TomoriBot
+
+Run `/providers`, choose **Add New Custom Endpoint**, and configure the Speech endpoint:
+
+- Capability: `Speech`
+- API Compatibility: `tts-clone`
+- Endpoint URL: `http://127.0.0.1:8016`
+- Voice Source Mode: `Auto`
+- Script Markup: `Plain`
+
+After saving the connection, select it and use its model dropdown to add a Speech model. Then open `/config` > Models > Switch Models and select the VoxCPM2 speech model.
+
+`Auto` is recommended because the same server supports reference-audio cloning and Voice Design. You do not need separate VoxCPM2 processes for the two modes.
+
+## Persona voice cloning
+
+For a persona that should clone an existing speaker:
+
+1. Prepare a clean reference clip with one speaker and little or no background music.
+2. Open `/config` under Models > TTS Parameters & Voices and upload the clip.
+3. Add the exact transcript of the reference clip when available. VoxCPM2 uses it for Ultimate Cloning and can reproduce more of the reference rhythm, emotion, and style.
+4. Open `/config` under Persona > Voice, choose the persona, and assign the saved sample.
+
+If no transcript is stored, VoxCPM2 still performs normal reference-audio cloning.
+
+## Persona Voice Design
+
+For a persona that should be created from a written voice description instead of a sample:
+
+1. Open `/config` under Persona > Voice and choose VoiceDesign.
+2. Choose the persona.
+3. Enter a natural-language description such as `Young adult woman, soft warm voice, relaxed pace, slightly playful delivery`.
+
+TomoriBot sends the saved description as `instruct`. VoxCPM2 converts it into its native Voice Design control prefix.
+
+When a cloned persona also receives one-off voice instructions, VoxCPM2 uses controllable cloning: the reference sample supplies the speaker identity while the instruction steers qualities such as emotion, pace, or delivery.
+
+## `/generate voice-message`
+
+Once VoxCPM2 is the active Speech model, `/generate voice-message` uses the persona's configured voice source in the same way as normal voice-message tool calls:
+
+- clone personas send the stored `ref_audio` and optional `ref_text`;
+- VoiceDesign personas send their saved prompt as `instruct`;
+- one-off voice instructions are passed through `instruct` and can steer controllable cloning.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `VOXCPM2_MODEL_ID` | `openbmb/VoxCPM2` | Hugging Face model ID or local model directory |
+| `VOXCPM2_DEVICE` | `auto` | Runtime device: `auto`, `cuda`, `cuda:N`, `cpu`, or `mps` |
+| `VOXCPM2_OPTIMIZE` | `1` | Enable the official runtime's optimization / compile path |
+| `VOXCPM2_LOAD_DENOISER` | `0` | Load the optional upstream denoiser; disabled by default to save memory |
+| `VOXCPM2_CFG_VALUE` | `2.0` | Guidance strength |
+| `VOXCPM2_INFERENCE_TIMESTEPS` | `10` | Flow-matching inference steps; more can improve quality at the cost of speed |
+| `VOXCPM2_MAX_LEN` | `4096` | Maximum generation length |
+| `VOXCPM2_NORMALIZE` | `0` | Enable upstream text normalization |
+| `VOXCPM2_RETRY_BADCASE` | `1` | Enable upstream retry behavior for abnormal generations |
+| `VOXCPM2_RETRY_BADCASE_MAX_TIMES` | `3` | Maximum automatic retries |
+| `VOXCPM2_RETRY_BADCASE_RATIO_THRESHOLD` | `6.0` | Upstream bad-case length threshold |
+| `VOXCPM2_SEED` | unset | Optional deterministic seed |
+| `VOXCPM2_PREFETCH` | `1` | Installer only: download the model during setup |
+| `TOMORI_TTS_HOST` | `127.0.0.1` | Sidecar bind address |
+| `TOMORI_TTS_PORT` | `8016` | Sidecar port |
+| `TOMORI_TTS_MAX_TEXT_CHARS` | `2000` | Maximum accepted synthesis text length |
+
+## Alternate checkpoints and runtimes
+
+The official BF16 model already fits the intended 16 GB consumer-GPU target, so TomoriBot does not default to a quantized checkpoint. Community quantizations exist, but they add another compatibility and maintenance layer without being necessary for the normal setup.
+
+For high-throughput deployments, OpenBMB currently points to Nano-vLLM-VoxCPM and vLLM-Omni as accelerated serving options. Those runtimes can expose streaming and concurrent-serving features beyond this reference sidecar. They are not required for TomoriBot's normal local voice-message workflow, and this wrapper deliberately stays on the official `voxcpm` API so upstream model upgrades remain easy to follow.

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
@@ -31,12 +31,12 @@ One VoxCPM2 endpoint can handle all useful TomoriBot voice-source modes:
 
 | TomoriBot request | VoxCPM2 behavior |
 |---|---|
-| `text` only | Normal zero-shot synthesis |
+| `text` only | Rejected; choose a reference sample or VoiceDesign prompt |
 | `text` + `instruct` | Voice Design from a natural-language description |
 | `text` + `ref_audio` | Reference-audio voice cloning |
 | `text` + `ref_audio` + `instruct` | Controllable cloning: preserve the speaker while steering delivery |
 | `text` + `ref_audio` + `ref_text` | Ultimate Cloning using the reference audio and its transcript |
-| `text` + `ref_audio` + `ref_text` + `instruct` | Transcript-assisted cloning plus natural-language delivery control |
+| `text` + `ref_audio` + `ref_text` + `instruct` | Controllable cloning; the one-off instruction takes precedence and the transcript is not sent |
 
 VoxCPM2 represents Voice Design and style control by placing a natural-language description in parentheses before the text to synthesize. TomoriBot already has an `instruct` field for this purpose, so the wrapper performs that conversion automatically.
 
@@ -94,6 +94,8 @@ $env:VOXCPM2_PREFETCH = "0"
 
 After setup, `bun run launch --voxcpm2` starts the sidecar together with TomoriBot. The default endpoint is `http://127.0.0.1:8016`.
 
+If `VOXCPM2_API_KEY` or `TOMORI_TTS_API_KEY` is set, register the endpoint with authentication enabled and save the same key in TomoriBot. The launcher still probes the unauthenticated `/health` route, while synthesis requests use `Authorization: Bearer <key>`.
+
 ## Register in TomoriBot
 
 Run `/providers`, choose **Add New Custom Endpoint**, and configure the Speech endpoint:
@@ -103,6 +105,7 @@ Run `/providers`, choose **Add New Custom Endpoint**, and configure the Speech e
 - Endpoint URL: `http://127.0.0.1:8016`
 - Voice Source Mode: `Auto`
 - Script Markup: `Plain`
+- Supports Instruct: `Yes`
 
 After saving the connection, select it and use its model dropdown to add a Speech model. Then open `/config` > Models > Switch Models and select the VoxCPM2 speech model.
 
@@ -129,7 +132,7 @@ For a persona that should be created from a written voice description instead of
 
 TomoriBot sends the saved description as `instruct`. VoxCPM2 converts it into its native Voice Design control prefix.
 
-When a cloned persona also receives one-off voice instructions, VoxCPM2 uses controllable cloning: the reference sample supplies the speaker identity while the instruction steers qualities such as emotion, pace, or delivery.
+When a cloned persona also receives one-off voice instructions, VoxCPM2 uses controllable cloning: the reference sample supplies the speaker identity while the instruction steers qualities such as emotion, pace, or delivery. If a transcript is also stored, the instruction takes precedence because the upstream Ultimate Cloning path does not provide a reliable control-instruction mode; the transcript is intentionally omitted for that request.
 
 ## `/generate voice-message`
 
@@ -137,7 +140,8 @@ Once VoxCPM2 is the active Speech model, `/generate voice-message` uses the pers
 
 - clone personas send the stored `ref_audio` and optional `ref_text`;
 - VoiceDesign personas send their saved prompt as `instruct`;
-- one-off voice instructions are passed through `instruct` and can steer controllable cloning.
+- clone-capable endpoints with Supports Instruct enabled expose the Delivery Direction field and pass one-off instructions through `instruct`;
+- when an instruction is present with a clone sample, TomoriBot uses `reference_wav_path` only and does not send the transcript prompt fields.
 
 ## Environment variables
 
@@ -155,9 +159,16 @@ Once VoxCPM2 is the active Speech model, `/generate voice-message` uses the pers
 | `VOXCPM2_RETRY_BADCASE_MAX_TIMES` | `3` | Maximum automatic retries |
 | `VOXCPM2_RETRY_BADCASE_RATIO_THRESHOLD` | `6.0` | Upstream bad-case length threshold |
 | `VOXCPM2_PREFETCH` | `1` | Installer only: download the model during setup |
+| `VOXCPM2_PORT` | `8016` | VoxCPM2 sidecar port; falls back to `TOMORI_TTS_PORT` when unset |
 | `TOMORI_TTS_HOST` | `127.0.0.1` | Sidecar bind address |
-| `TOMORI_TTS_PORT` | `8016` | Sidecar port |
+| `TOMORI_TTS_PORT` | `8016` | Backward-compatible shared sidecar port fallback |
+| `VOXCPM2_MAX_REF_AUDIO_BYTES` | `10485760` | Maximum decoded reference-audio size |
+| `VOXCPM2_API_KEY` | unset | Optional bearer token for `/synthesize`; `TOMORI_TTS_API_KEY` is accepted as a fallback |
+| `TOMORI_TTS_API_KEY` | unset | Shared optional bearer token fallback for `/synthesize` |
+| `TOMORI_TTS_ALLOW_REMOTE_BIND` | `0` | Set to `1` only to allow a non-loopback bind without a bearer token |
 | `TOMORI_TTS_MAX_TEXT_CHARS` | `2000` | Maximum accepted synthesis text length |
+
+Reference audio must be a non-empty WAV container. The wrapper enforces the decoded byte limit before writing a temporary file. `/health` remains unauthenticated for local readiness checks; `/synthesize` requires `Authorization: Bearer <key>` whenever a key is configured. Keep the default loopback bind unless a reverse proxy or explicit remote policy is in place.
 
 ## Alternate checkpoints and runtimes
 

--- a/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
+++ b/docs/en/self-hosting/local-endpoints/text-to-speech/voxcpm2.md
@@ -154,7 +154,6 @@ Once VoxCPM2 is the active Speech model, `/generate voice-message` uses the pers
 | `VOXCPM2_RETRY_BADCASE` | `1` | Enable upstream retry behavior for abnormal generations |
 | `VOXCPM2_RETRY_BADCASE_MAX_TIMES` | `3` | Maximum automatic retries |
 | `VOXCPM2_RETRY_BADCASE_RATIO_THRESHOLD` | `6.0` | Upstream bad-case length threshold |
-| `VOXCPM2_SEED` | unset | Optional deterministic seed |
 | `VOXCPM2_PREFETCH` | `1` | Installer only: download the model during setup |
 | `TOMORI_TTS_HOST` | `127.0.0.1` | Sidecar bind address |
 | `TOMORI_TTS_PORT` | `8016` | Sidecar port |

--- a/scripts/devtools/launch.ts
+++ b/scripts/devtools/launch.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { config } from "dotenv";
 import pc from "picocolors";
 import { resolvePythonExe } from "../lib/pyenv";
+import { DEFAULT_PYTHON_HEALTH_TIMEOUT_MS, resolvePositiveTimeoutMs } from "../lib/launchReadiness";
 
 config();
 
@@ -331,7 +332,10 @@ async function startPythonSidecar(
     venvRelPath,
     scriptRelPath,
     scriptArgs = [],
-    healthTimeoutMs = Number.parseInt(process.env.TOMORI_TTS_STARTUP_TIMEOUT_MS ?? "300000", 10),
+    healthTimeoutMs = resolvePositiveTimeoutMs(
+      process.env.TOMORI_TTS_STARTUP_TIMEOUT_MS,
+      DEFAULT_PYTHON_HEALTH_TIMEOUT_MS,
+    ),
   } = def;
   const label = pc.magenta(`[${displayName}]`);
 

--- a/scripts/devtools/launch.ts
+++ b/scripts/devtools/launch.ts
@@ -16,7 +16,7 @@ config();
 //
 //   Docker sidecars are started via docker inspect/start/run and polled until
 //   their healthcheck reports "healthy". Python sidecars are spawned directly
-//   from their pre-built venv and given a configurable startup delay.
+//   from their pre-built venv and polled through their JSON health endpoint.
 //
 //   Press Ctrl+C to stop everything.
 
@@ -80,8 +80,12 @@ interface PythonSidecar {
   scriptRelPath: string;
   /** extra args passed to the script */
   scriptArgs?: string[];
-  /** milliseconds to wait after spawn before proceeding (default 3s) */
-  startupDelayMs?: number;
+  /** JSON health endpoint used to distinguish loading from ready. */
+  healthUrl: string;
+  /** Status values that mean the server can accept requests. */
+  readyStatuses?: readonly string[];
+  /** Maximum time to wait for the model to become ready. */
+  healthTimeoutMs?: number;
 }
 
 type SidecarDef = DockerSidecar | PythonSidecar;
@@ -135,7 +139,8 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "Qwen3-TTS",
     venvRelPath: "servers/tts/qwen3tts/.venv",
     scriptRelPath: "servers/tts/qwen3tts/server.py",
-    startupDelayMs: 5_000,
+    healthUrl: `http://127.0.0.1:${process.env.TOMORI_TTS_PORT ?? "8012"}/health`,
+    readyStatuses: ["ok", "idle"],
   },
 
   chatterbox: {
@@ -143,7 +148,7 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "Chatterbox TTS",
     venvRelPath: "servers/tts/chatterbox/.venv",
     scriptRelPath: "servers/tts/chatterbox/server.py",
-    startupDelayMs: 5_000,
+    healthUrl: `http://127.0.0.1:${process.env.TOMORI_TTS_PORT ?? "8011"}/health`,
   },
 
   irodoritts: {
@@ -151,7 +156,7 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "IrodoriTTS",
     venvRelPath: "servers/tts/irodoritts/.venv",
     scriptRelPath: "servers/tts/irodoritts/server.py",
-    startupDelayMs: 8_000,
+    healthUrl: `http://127.0.0.1:${process.env.TOMORI_TTS_PORT ?? "8013"}/health`,
   },
 
   voxcpm2: {
@@ -159,7 +164,7 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "VoxCPM2",
     venvRelPath: "servers/tts/voxcpm2/.venv",
     scriptRelPath: "servers/tts/voxcpm2/server.py",
-    startupDelayMs: 15_000,
+    healthUrl: `http://127.0.0.1:${process.env.VOXCPM2_PORT ?? process.env.TOMORI_TTS_PORT ?? "8016"}/health`,
   },
 
   whisperx: {
@@ -167,7 +172,7 @@ const SIDECARS: Record<string, SidecarDef> = {
     displayName: "WhisperX",
     venvRelPath: "servers/stt/.venv",
     scriptRelPath: "servers/stt/whisperx_server.py",
-    startupDelayMs: 10_000,
+    healthUrl: `http://127.0.0.1:${process.env.TOMORI_STT_PORT ?? process.env.TOMORI_TRANSCRIPTION_PORT ?? "8021"}/health`,
   },
 };
 
@@ -230,6 +235,51 @@ async function waitForHealthy(def: DockerSidecar, timeoutMs: number): Promise<vo
   throw new Error(`Container "${containerName}" did not become healthy within ${timeoutMs / 1000}s.`);
 }
 
+type PythonHealthResult =
+  | { kind: "ready"; ready: boolean }
+  | { kind: "exit"; code: number }
+  | { kind: "retry" };
+
+async function probeJsonHealth(url: string, readyStatuses: readonly string[]): Promise<boolean> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(3_000) });
+    if (!response.ok) return false;
+    const payload: unknown = await response.json();
+    if (!payload || typeof payload !== "object" || !("status" in payload)) return false;
+    const status = payload.status;
+    return typeof status === "string" && readyStatuses.includes(status);
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPythonReady(
+  proc: ReturnType<typeof Bun.spawn>,
+  def: PythonSidecar,
+  timeoutMs: number,
+): Promise<void> {
+  const readyStatuses = def.readyStatuses ?? ["ok"];
+  const processExit = proc.exited.then((code): PythonHealthResult => ({ kind: "exit", code }));
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = await Promise.race<PythonHealthResult>([
+      probeJsonHealth(def.healthUrl, readyStatuses).then(
+        (ready): PythonHealthResult => ({ kind: "ready", ready }),
+      ),
+      processExit,
+      Bun.sleep(1_000).then((): PythonHealthResult => ({ kind: "retry" })),
+    ]);
+
+    if (result.kind === "exit") {
+      throw new Error(`Process exited before readiness (exit ${result.code}).`);
+    }
+    if (result.kind === "ready" && result.ready) return;
+  }
+
+  throw new Error(`Server did not report a ready JSON status within ${timeoutMs / 1000}s.`);
+}
+
 /**
  * Ensures a Docker sidecar is running. Creates the container via "docker run"
  * if it doesn't exist, or resumes it with "docker start" if it does.
@@ -268,15 +318,21 @@ async function ensureDockerSidecar(def: DockerSidecar): Promise<void> {
 
 
 /**
- * Spawns a Python sidecar server from its pre-built venv and waits
- * `startupDelayMs` milliseconds for it to bind before returning the handle.
+ * Spawns a Python sidecar server from its pre-built venv and waits for JSON readiness before
+ * returning the handle.
  * Throws if the venv is missing (user must run setup first).
  */
 async function startPythonSidecar(
   def: PythonSidecar,
   flagName: string,
 ): Promise<ReturnType<typeof Bun.spawn>> {
-  const { displayName, venvRelPath, scriptRelPath, scriptArgs = [], startupDelayMs = 3_000 } = def;
+  const {
+    displayName,
+    venvRelPath,
+    scriptRelPath,
+    scriptArgs = [],
+    healthTimeoutMs = Number.parseInt(process.env.TOMORI_TTS_STARTUP_TIMEOUT_MS ?? "300000", 10),
+  } = def;
   const label = pc.magenta(`[${displayName}]`);
 
   const pythonExe = resolvePythonExe(venvRelPath);
@@ -296,10 +352,14 @@ async function startPythonSidecar(
     cwd: ROOT,
   });
 
-  // Give the Python HTTP server time to bind its port.
-  console.log(`${label} Waiting ${startupDelayMs / 1000}s for server to initialize...`);
-  await Bun.sleep(startupDelayMs);
-  console.log(`${label} ${pc.green("Started ✓")}`);
+  console.log(`${label} Waiting for JSON readiness (up to ${healthTimeoutMs / 1000}s)...`);
+  try {
+    await waitForPythonReady(proc, def, healthTimeoutMs);
+  } catch (error) {
+    try { proc.kill(); } catch { /* already exited */ }
+    throw new Error(`${displayName} did not become ready: ${error instanceof Error ? error.message : error}`);
+  }
+  console.log(`${label} ${pc.green("Ready ✓")}`);
 
   return proc;
 }

--- a/scripts/devtools/launch.ts
+++ b/scripts/devtools/launch.ts
@@ -9,7 +9,7 @@ config();
 
 // scripts/devtools/launch.ts
 //
-//   bun run launch [--searxng] [--crawl4ai] [--qwen3tts] [--chatterbox] [--irodoritts]
+//   bun run launch [--searxng] [--crawl4ai] [--qwen3tts] [--chatterbox] [--irodoritts] [--voxcpm2]
 //
 //   Starts requested sidecar services, waits for them to be ready, then
 //   launches the bot in watch mode (equivalent to `bun run dev`).
@@ -39,6 +39,7 @@ ${pc.bold("Options:")}
   --qwen3tts    Start the Qwen3-TTS Python server (requires venv setup)
   --chatterbox  Start the Chatterbox TTS Python server (requires venv setup)
   --irodoritts  Start the IrodoriTTS Python server (requires venv setup)
+  --voxcpm2     Start the VoxCPM2 Python server (requires venv setup)
   --whisperx    Start the WhisperX transcription Python server (requires venv setup)
   --help        Show this message
 
@@ -46,6 +47,7 @@ ${pc.bold("Examples:")}
   bun run launch
   bun run launch --searxng --crawl4ai
   bun run launch --qwen3tts --searxng
+  bun run launch --voxcpm2
 `);
   process.exit(0);
 }
@@ -150,6 +152,14 @@ const SIDECARS: Record<string, SidecarDef> = {
     venvRelPath: "servers/tts/irodoritts/.venv",
     scriptRelPath: "servers/tts/irodoritts/server.py",
     startupDelayMs: 8_000,
+  },
+
+  voxcpm2: {
+    kind: "python",
+    displayName: "VoxCPM2",
+    venvRelPath: "servers/tts/voxcpm2/.venv",
+    scriptRelPath: "servers/tts/voxcpm2/server.py",
+    startupDelayMs: 15_000,
   },
 
   whisperx: {
@@ -262,7 +272,10 @@ async function ensureDockerSidecar(def: DockerSidecar): Promise<void> {
  * `startupDelayMs` milliseconds for it to bind before returning the handle.
  * Throws if the venv is missing (user must run setup first).
  */
-async function startPythonSidecar(def: PythonSidecar): Promise<ReturnType<typeof Bun.spawn>> {
+async function startPythonSidecar(
+  def: PythonSidecar,
+  flagName: string,
+): Promise<ReturnType<typeof Bun.spawn>> {
   const { displayName, venvRelPath, scriptRelPath, scriptArgs = [], startupDelayMs = 3_000 } = def;
   const label = pc.magenta(`[${displayName}]`);
 
@@ -270,7 +283,7 @@ async function startPythonSidecar(def: PythonSidecar): Promise<ReturnType<typeof
   if (!existsSync(pythonExe)) {
     throw new Error(
       `${displayName} venv not found at "${join(ROOT, venvRelPath)}". ` +
-      `Run the setup instructions in the docs before using --${displayName.toLowerCase().replace(/[^a-z]/g, "")}.`,
+      `Run the setup instructions in the docs before using --${flagName}.`,
     );
   }
 
@@ -308,7 +321,7 @@ async function main(): Promise<void> {
       if (def.kind === "docker") {
         await ensureDockerSidecar(def);
       } else {
-        const proc = await startPythonSidecar(def);
+        const proc = await startPythonSidecar(def, flag);
         childProcesses.push(proc);
       }
     } catch (err) {

--- a/scripts/lib/launchReadiness.ts
+++ b/scripts/lib/launchReadiness.ts
@@ -1,0 +1,11 @@
+/** Default wait for a Python sidecar to report a ready health status. */
+export const DEFAULT_PYTHON_HEALTH_TIMEOUT_MS = 300_000;
+
+/**
+ * Resolves a positive timeout override without allowing malformed configuration to skip readiness.
+ */
+export function resolvePositiveTimeoutMs(rawValue: string | undefined, fallbackMs: number): number {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallbackMs;
+  return Math.max(1, Math.ceil(parsed));
+}

--- a/servers/tts/README.md
+++ b/servers/tts/README.md
@@ -56,4 +56,4 @@ Qwen3-TTS defaults to auto mode. One server URL can handle both clone and VoiceD
 
 Irodori-TTS v4.1 also supports TomoriBot's `Auto` voice source mode from one endpoint. Clone requests use `ref_audio`; VoiceDesign requests use `instruct`, which the wrapper maps to Irodori caption conditioning.
 
-VoxCPM2 uses one official `openbmb/VoxCPM2` model for all modes. Reference audio maps to normal cloning, reference audio plus its stored transcript maps to Ultimate Cloning, and `instruct` is converted into VoxCPM2's natural-language Voice Design / controllable-cloning prefix. Use Voice Source Mode `Auto` and Script Markup `Plain`.
+VoxCPM2 uses one official `openbmb/VoxCPM2` model for all modes. Reference audio maps to normal cloning, reference audio plus its stored transcript maps to Ultimate Cloning, and `instruct` is converted into VoxCPM2's natural-language Voice Design / controllable-cloning prefix. Register it with Voice Source Mode `Auto`, Script Markup `Plain`, and Supports Instruct `Yes`. If a clone request includes both a transcript and one-off instruction, the instruction path wins and the transcript prompt is omitted.

--- a/servers/tts/README.md
+++ b/servers/tts/README.md
@@ -1,6 +1,6 @@
 # TomoriBot Reference TTS Servers
 
-These scripts are optional local wrapper servers for Phase 4 speech endpoints. They expose TomoriBot's `POST /synthesize` contract and keep model weights outside the Bun app.
+These scripts are optional local wrapper servers for TomoriBot speech endpoints. They expose TomoriBot's `POST /synthesize` contract and keep model weights outside the Bun app.
 
 Each engine lives in its own subfolder with its own `.venv` to keep dependencies isolated:
 
@@ -10,54 +10,52 @@ Each engine lives in its own subfolder with its own `.venv` to keep dependencies
 | Qwen3-TTS 12Hz 1.7B Base / VoiceDesign auto mode (10 languages, plain text) | `qwen3tts/` | 8012 |
 | Irodori-TTS v4.1 (Japanese, clone + VoiceDesign, emoji tags) | `irodoritts/` | 8013 |
 | Qwen3-TTS 12Hz 1.7B VoiceDesign (natural-language voice descriptions) | `qwen3tts/server.py --mode voice-design` | 8014 |
+| VoxCPM2 2B (30 languages, clone + VoiceDesign + controllable cloning) | `voxcpm2/` | 8016 |
+
+Port 8015 is intentionally left available for the Fish Audio S2 Pro sidecar proposed separately in PR #85.
 
 ## Prerequisites
 
-- **Python 3.10+**
-- **CUDA 12.x + drivers** *(optional)* — required for GPU acceleration; without it servers fall back to CPU (significantly slower)
+- **Python 3.10+**. VoxCPM2 currently requires Python 3.10-3.12.
+- **CUDA-capable NVIDIA GPU** *(optional)* for fast local synthesis. CPU fallbacks are significantly slower.
+- **ffmpeg** for TomoriBot voice-sample normalization.
 
-## Setup (Windows PowerShell)
+## Setup
 
-Run these commands from the repo root. Swap in the folder name for the engine you want.
+Each sidecar has its own setup guide under `docs/en/self-hosting/local-endpoints/text-to-speech/`. Modern sidecars include installer scripts where their upstream runtimes make that practical.
+
+For VoxCPM2:
 
 ```powershell
-# 1. Create and activate a virtual environment inside the engine folder
-python -m venv servers\tts\chatterbox\.venv
-servers\tts\chatterbox\.venv\Scripts\Activate.ps1
-
-# 2. Upgrade pip
-python -m pip install -U pip
-
-# 3. Install dependencies
-#    Chatterbox: install numpy first (pkuseg build-time dependency)
-python -m pip install numpy
-python -m pip install -r servers\tts\chatterbox\requirements.txt
-
-# 4. (GPU only) Reinstall PyTorch with CUDA support — skip for CPU-only installs
-pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu124
-
-# 5. Start the server
-python servers\tts\chatterbox\server.py
+# Windows PowerShell
+.\servers\tts\voxcpm2\install-voxcpm2.ps1
 ```
 
-> **CUDA version**: use `cu118` or `cu121` in the index URL above if your driver targets an older toolkit.
+```bash
+# Linux / WSL
+bash servers/tts/voxcpm2/install-voxcpm2.sh
+```
 
-Qwen3-TTS follows a similar venv + requirements flow. Irodori-TTS uses `uv` and backend extras instead; see `docs/en/self-hosting/local-endpoints/text-to-speech/irodoritts.md` for its current setup.
+After setup, start it directly or use the launcher:
+
+```sh
+bun run launch --voxcpm2
+```
 
 ## Registering in TomoriBot
 
-After the server is running, register it with `/provider custom-endpoint add`:
+Run `/providers`, choose **Add New Custom Endpoint**, and register the server as a Speech endpoint using API Compatibility `tts-clone`. Use the endpoint URL and voice-source mode documented for that engine.
 
-- `capability = speech`
-- `api_style = tts-clone`
-- `endpoint_url = http://127.0.0.1:<port>`
-- `script_markup` — select the correct option for the engine
+Then use `/providers` to add the Speech model, and `/config` > Models > Switch Models to activate it.
 
-> **ffmpeg required**: voice sample uploads are normalised to WAV via ffmpeg. Install it
-> and ensure `ffmpeg` is on your PATH before adding a sample in `/config` under Models > TTS Parameters & Voices.
+For voice samples, open `/config` under Models > TTS Parameters & Voices. TomoriBot normalizes uploaded samples to WAV with ffmpeg. Assign clone samples or VoiceDesign prompts to personas under `/config` > Persona > Voice.
+
+## Engine notes
 
 Chatterbox defaults to Turbo. Use `/config` under Models > TTS Parameters & Voices to disable Turbo and set standard-model `cfg_weight` and `exaggeration` values for generated voice messages.
 
-Qwen3-TTS defaults to auto mode. One server URL can handle both clone and VoiceDesign requests: the server detects clone requests by `ref_audio`, detects VoiceDesign requests by `instruct`, and swaps the loaded model when needed. Start VoiceDesign only with `TOMORI_TTS_MODE=voice-design python servers/tts/qwen3tts/server.py` or `python servers/tts/qwen3tts/server.py --mode voice-design`. In TomoriBot, set persona prompts with `/speech voice-design set`; generated tool calls send that prompt as `instruct`.
+Qwen3-TTS defaults to auto mode. One server URL can handle both clone and VoiceDesign requests: the server detects clone requests by `ref_audio`, detects VoiceDesign requests by `instruct`, and swaps the loaded model when needed. Start VoiceDesign only with `TOMORI_TTS_MODE=voice-design python servers/tts/qwen3tts/server.py` or `python servers/tts/qwen3tts/server.py --mode voice-design`.
 
 Irodori-TTS v4.1 also supports TomoriBot's `Auto` voice source mode from one endpoint. Clone requests use `ref_audio`; VoiceDesign requests use `instruct`, which the wrapper maps to Irodori caption conditioning.
+
+VoxCPM2 uses one official `openbmb/VoxCPM2` model for all modes. Reference audio maps to normal cloning, reference audio plus its stored transcript maps to Ultimate Cloning, and `instruct` is converted into VoxCPM2's natural-language Voice Design / controllable-cloning prefix. Use Voice Source Mode `Auto` and Script Markup `Plain`.

--- a/servers/tts/README.md
+++ b/servers/tts/README.md
@@ -12,8 +12,6 @@ Each engine lives in its own subfolder with its own `.venv` to keep dependencies
 | Qwen3-TTS 12Hz 1.7B VoiceDesign (natural-language voice descriptions) | `qwen3tts/server.py --mode voice-design` | 8014 |
 | VoxCPM2 2B (30 languages, clone + VoiceDesign + controllable cloning) | `voxcpm2/` | 8016 |
 
-Port 8015 is intentionally left available for the Fish Audio S2 Pro sidecar proposed separately in PR #85.
-
 ## Prerequisites
 
 - **Python 3.10+**. VoxCPM2 currently requires Python 3.10-3.12.

--- a/servers/tts/voxcpm2/install-voxcpm2.ps1
+++ b/servers/tts/voxcpm2/install-voxcpm2.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$VenvDir = Join-Path $ScriptDir ".venv"
+$PythonBin = if ($env:PYTHON_BIN) { $env:PYTHON_BIN } else { "python" }
+$ModelId = if ($env:VOXCPM2_MODEL_ID) { $env:VOXCPM2_MODEL_ID } else { "openbmb/VoxCPM2" }
+
+& $PythonBin -c "import sys; assert (3, 10) <= sys.version_info[:2] < (3, 13), 'VoxCPM2 requires Python 3.10-3.12.'"
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+& $PythonBin -m venv $VenvDir
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+& $VenvPython -m pip install --upgrade pip setuptools wheel
+& $VenvPython -m pip install -r (Join-Path $ScriptDir "requirements.txt")
+
+if ($env:VOXCPM2_PREFETCH -ne "0") {
+  Write-Host "Downloading $ModelId into the Hugging Face cache..."
+  $env:VOXCPM2_MODEL_ID = $ModelId
+  & $VenvPython -c "import os; from huggingface_hub import snapshot_download; snapshot_download(os.environ['VOXCPM2_MODEL_ID'])"
+}
+
+$TorchCheck = @'
+import torch
+print(f"PyTorch: {torch.__version__}")
+print(f"CUDA available: {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"CUDA device: {torch.cuda.get_device_name(0)}")
+else:
+    print("No CUDA device detected. VoxCPM2 will run on CPU unless VOXCPM2_DEVICE selects another supported device.")
+'@
+& $VenvPython -c $TorchCheck
+
+Write-Host "VoxCPM2 setup complete."
+Write-Host "Start: $VenvPython $(Join-Path $ScriptDir 'server.py')"

--- a/servers/tts/voxcpm2/install-voxcpm2.sh
+++ b/servers/tts/voxcpm2/install-voxcpm2.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+MODEL_ID="${VOXCPM2_MODEL_ID:-openbmb/VoxCPM2}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "$PYTHON_BIN is required (Python 3.10-3.12)." >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" - <<'PY'
+import sys
+if not ((3, 10) <= sys.version_info[:2] < (3, 13)):
+    raise SystemExit("VoxCPM2 requires Python 3.10-3.12.")
+PY
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+"$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel
+"$VENV_DIR/bin/python" -m pip install -r "$SCRIPT_DIR/requirements.txt"
+
+if [ "${VOXCPM2_PREFETCH:-1}" = "1" ]; then
+  echo "Downloading ${MODEL_ID} into the Hugging Face cache..."
+  VOXCPM2_MODEL_ID="$MODEL_ID" "$VENV_DIR/bin/python" - <<'PY'
+import os
+from huggingface_hub import snapshot_download
+snapshot_download(os.environ["VOXCPM2_MODEL_ID"])
+PY
+fi
+
+"$VENV_DIR/bin/python" - <<'PY'
+import torch
+print(f"PyTorch: {torch.__version__}")
+print(f"CUDA available: {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"CUDA device: {torch.cuda.get_device_name(0)}")
+else:
+    print("No CUDA device detected. VoxCPM2 will run on CPU unless VOXCPM2_DEVICE selects another supported device.")
+PY
+
+echo "VoxCPM2 setup complete."
+echo "Start: $VENV_DIR/bin/python $SCRIPT_DIR/server.py"

--- a/servers/tts/voxcpm2/requirements-test.txt
+++ b/servers/tts/voxcpm2/requirements-test.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115,<1
+numpy>=1.26,<3
+soundfile>=0.12,<1
+uvicorn>=0.30,<1

--- a/servers/tts/voxcpm2/requirements.txt
+++ b/servers/tts/voxcpm2/requirements.txt
@@ -1,0 +1,4 @@
+voxcpm==2.0.3
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30,<1
+soundfile>=0.12

--- a/servers/tts/voxcpm2/server.py
+++ b/servers/tts/voxcpm2/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import hmac
 import io
 import os
 import tempfile
@@ -8,11 +9,11 @@ import threading
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 import soundfile as sf
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -22,8 +23,11 @@ DEVICE = os.getenv("VOXCPM2_DEVICE", "auto")
 OPTIMIZE = os.getenv("VOXCPM2_OPTIMIZE", "1").lower() in {"1", "true", "yes", "on"}
 LOAD_DENOISER = os.getenv("VOXCPM2_LOAD_DENOISER", "0").lower() in {"1", "true", "yes", "on"}
 HOST = os.getenv("TOMORI_TTS_HOST", "127.0.0.1")
-PORT = int(os.getenv("TOMORI_TTS_PORT", "8016"))
+PORT = int(os.getenv("VOXCPM2_PORT", os.getenv("TOMORI_TTS_PORT", "8016")))
 MAX_TEXT_CHARS = int(os.getenv("TOMORI_TTS_MAX_TEXT_CHARS", "2000"))
+MAX_REF_AUDIO_BYTES = int(os.getenv("VOXCPM2_MAX_REF_AUDIO_BYTES", str(10 * 1024 * 1024)))
+API_KEY = (os.getenv("VOXCPM2_API_KEY") or os.getenv("TOMORI_TTS_API_KEY", "")).strip()
+ALLOW_REMOTE_BIND = os.getenv("TOMORI_TTS_ALLOW_REMOTE_BIND", "0").lower() in {"1", "true", "yes", "on"}
 CFG_VALUE = float(os.getenv("VOXCPM2_CFG_VALUE", "2.0"))
 INFERENCE_TIMESTEPS = int(os.getenv("VOXCPM2_INFERENCE_TIMESTEPS", "10"))
 MAX_LEN = int(os.getenv("VOXCPM2_MAX_LEN", "4096"))
@@ -64,13 +68,48 @@ def controlled_text(text: str, instruct: Optional[str]) -> str:
     return f"({control}){text}"
 
 
+def is_loopback_host(host: str) -> bool:
+    return host.strip().lower() in {"127.0.0.1", "localhost", "::1"}
+
+
+def validate_bind_policy() -> None:
+    if not is_loopback_host(HOST) and not API_KEY and not ALLOW_REMOTE_BIND:
+        raise RuntimeError(
+            "Refusing non-loopback bind without VOXCPM2_API_KEY or "
+            "TOMORI_TTS_ALLOW_REMOTE_BIND=1."
+        )
+
+
+def require_bearer_token(authorization: Optional[str]) -> None:
+    if not API_KEY:
+        return
+    expected = f"Bearer {API_KEY}"
+    if not authorization or not hmac.compare_digest(authorization.strip(), expected):
+        raise HTTPException(status_code=401, detail="A valid bearer token is required.")
+
+
 def decode_ref_audio(raw_base64: str, directory: str) -> str:
+    max_encoded_chars = ((MAX_REF_AUDIO_BYTES + 2) // 3) * 4
+    if len(raw_base64) > max_encoded_chars:
+        raise HTTPException(status_code=413, detail=f"ref_audio exceeds {MAX_REF_AUDIO_BYTES} decoded bytes.")
+
     try:
         audio_bytes = base64.b64decode(raw_base64, validate=True)
     except Exception as exc:
         raise HTTPException(status_code=400, detail="ref_audio must be valid base64.") from exc
     if not audio_bytes:
         raise HTTPException(status_code=400, detail="ref_audio must not be empty.")
+    if len(audio_bytes) > MAX_REF_AUDIO_BYTES:
+        raise HTTPException(status_code=413, detail=f"ref_audio exceeds {MAX_REF_AUDIO_BYTES} decoded bytes.")
+
+    try:
+        info = sf.info(io.BytesIO(audio_bytes))
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="ref_audio must be a readable audio container.") from exc
+    if info.format.upper() != "WAV":
+        raise HTTPException(status_code=400, detail="ref_audio must be a WAV container.")
+    if info.frames <= 0 or info.samplerate <= 0 or info.channels <= 0:
+        raise HTTPException(status_code=400, detail="ref_audio must contain a non-empty audio stream.")
 
     ref_path = Path(directory) / "reference.wav"
     ref_path.write_bytes(audio_bytes)
@@ -124,7 +163,11 @@ def health() -> dict[str, str | bool | int | float | None]:
 
 
 @app.post("/synthesize")
-def synthesize(payload: SynthesizeRequest) -> Response:
+def synthesize(
+    payload: SynthesizeRequest,
+    authorization: Annotated[Optional[str], Header()] = None,
+) -> Response:
+    require_bearer_token(authorization)
     if model is None:
         raise HTTPException(status_code=503, detail="VoxCPM2 is still loading.")
 
@@ -137,6 +180,12 @@ def synthesize(payload: SynthesizeRequest) -> Response:
     synthesis_text = controlled_text(text, payload.instruct)
     ref_text = payload.ref_text.strip() if payload.ref_text else ""
     has_ref_audio = bool(payload.ref_audio and payload.ref_audio.strip())
+    has_instruct = bool(payload.instruct and payload.instruct.strip())
+
+    if not has_ref_audio and not has_instruct:
+        raise HTTPException(status_code=400, detail="Send ref_audio for cloning or instruct for Voice Design.")
+    if ref_text and not has_ref_audio:
+        raise HTTPException(status_code=400, detail="ref_text requires ref_audio.")
 
     with tempfile.TemporaryDirectory(prefix="tomori-voxcpm2-") as temp_dir:
         reference_path = decode_ref_audio(payload.ref_audio, temp_dir) if has_ref_audio else None
@@ -153,14 +202,14 @@ def synthesize(payload: SynthesizeRequest) -> Response:
             "retry_badcase_ratio_threshold": RETRY_BADCASE_RATIO_THRESHOLD,
         }
 
-        mode = "voice-design" if payload.instruct and not has_ref_audio else "zero-shot"
+        mode = "voice-design" if has_instruct and not has_ref_audio else "clone"
         if reference_path:
             kwargs["reference_wav_path"] = reference_path
-            mode = "controllable-clone" if payload.instruct else "clone"
-            if ref_text:
+            mode = "controllable-clone" if has_instruct else "clone"
+            if ref_text and not has_instruct:
                 kwargs["prompt_wav_path"] = reference_path
                 kwargs["prompt_text"] = ref_text
-                mode = "ultimate-controllable-clone" if payload.instruct else "ultimate-clone"
+                mode = "ultimate-clone"
 
         started_at = time.perf_counter()
         with model_lock:
@@ -181,4 +230,5 @@ def synthesize(payload: SynthesizeRequest) -> Response:
 
 
 if __name__ == "__main__":
+    validate_bind_policy()
     uvicorn.run(app, host=HOST, port=PORT)

--- a/servers/tts/voxcpm2/server.py
+++ b/servers/tts/voxcpm2/server.py
@@ -31,8 +31,6 @@ NORMALIZE = os.getenv("VOXCPM2_NORMALIZE", "0").lower() in {"1", "true", "yes", 
 RETRY_BADCASE = os.getenv("VOXCPM2_RETRY_BADCASE", "1").lower() in {"1", "true", "yes", "on"}
 RETRY_BADCASE_MAX_TIMES = int(os.getenv("VOXCPM2_RETRY_BADCASE_MAX_TIMES", "3"))
 RETRY_BADCASE_RATIO_THRESHOLD = float(os.getenv("VOXCPM2_RETRY_BADCASE_RATIO_THRESHOLD", "6.0"))
-SEED_RAW = os.getenv("VOXCPM2_SEED", "").strip()
-SEED = int(SEED_RAW) if SEED_RAW else None
 
 model = None
 model_lock = threading.Lock()
@@ -153,7 +151,6 @@ def synthesize(payload: SynthesizeRequest) -> Response:
             "retry_badcase": RETRY_BADCASE,
             "retry_badcase_max_times": RETRY_BADCASE_MAX_TIMES,
             "retry_badcase_ratio_threshold": RETRY_BADCASE_RATIO_THRESHOLD,
-            "seed": SEED,
         }
 
         mode = "voice-design" if payload.instruct and not has_ref_audio else "zero-shot"

--- a/servers/tts/voxcpm2/server.py
+++ b/servers/tts/voxcpm2/server.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import base64
+import io
+import os
+import tempfile
+import threading
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Optional
+
+import soundfile as sf
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+
+MODEL_ID = os.getenv("VOXCPM2_MODEL_ID", "openbmb/VoxCPM2")
+DEVICE = os.getenv("VOXCPM2_DEVICE", "auto")
+OPTIMIZE = os.getenv("VOXCPM2_OPTIMIZE", "1").lower() in {"1", "true", "yes", "on"}
+LOAD_DENOISER = os.getenv("VOXCPM2_LOAD_DENOISER", "0").lower() in {"1", "true", "yes", "on"}
+HOST = os.getenv("TOMORI_TTS_HOST", "127.0.0.1")
+PORT = int(os.getenv("TOMORI_TTS_PORT", "8016"))
+MAX_TEXT_CHARS = int(os.getenv("TOMORI_TTS_MAX_TEXT_CHARS", "2000"))
+CFG_VALUE = float(os.getenv("VOXCPM2_CFG_VALUE", "2.0"))
+INFERENCE_TIMESTEPS = int(os.getenv("VOXCPM2_INFERENCE_TIMESTEPS", "10"))
+MAX_LEN = int(os.getenv("VOXCPM2_MAX_LEN", "4096"))
+NORMALIZE = os.getenv("VOXCPM2_NORMALIZE", "0").lower() in {"1", "true", "yes", "on"}
+RETRY_BADCASE = os.getenv("VOXCPM2_RETRY_BADCASE", "1").lower() in {"1", "true", "yes", "on"}
+RETRY_BADCASE_MAX_TIMES = int(os.getenv("VOXCPM2_RETRY_BADCASE_MAX_TIMES", "3"))
+RETRY_BADCASE_RATIO_THRESHOLD = float(os.getenv("VOXCPM2_RETRY_BADCASE_RATIO_THRESHOLD", "6.0"))
+SEED_RAW = os.getenv("VOXCPM2_SEED", "").strip()
+SEED = int(SEED_RAW) if SEED_RAW else None
+
+model = None
+model_lock = threading.Lock()
+
+
+class SynthesizeRequest(BaseModel):
+    text: str
+    ref_audio: Optional[str] = None
+    ref_text: Optional[str] = None
+    instruct: Optional[str] = None
+    language: Optional[str] = None
+
+
+def log_info(message: str) -> None:
+    print(f"[VoxCPM2] {message}", flush=True)
+
+
+def resolve_device() -> Optional[str]:
+    normalized = DEVICE.strip().lower()
+    if normalized in {"", "auto"}:
+        return None
+    return DEVICE.strip()
+
+
+def controlled_text(text: str, instruct: Optional[str]) -> str:
+    control = (instruct or "").strip()
+    if not control:
+        return text
+    if control.startswith("(") and control.endswith(")"):
+        return f"{control}{text}"
+    return f"({control}){text}"
+
+
+def decode_ref_audio(raw_base64: str, directory: str) -> str:
+    try:
+        audio_bytes = base64.b64decode(raw_base64, validate=True)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="ref_audio must be valid base64.") from exc
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="ref_audio must not be empty.")
+
+    ref_path = Path(directory) / "reference.wav"
+    ref_path.write_bytes(audio_bytes)
+    return str(ref_path)
+
+
+def load_model() -> None:
+    global model
+    from voxcpm import VoxCPM
+
+    started_at = time.perf_counter()
+    log_info(
+        f"Loading model_id={MODEL_ID} device={DEVICE} optimize={OPTIMIZE} denoiser={LOAD_DENOISER}"
+    )
+    model = VoxCPM.from_pretrained(
+        MODEL_ID,
+        load_denoiser=LOAD_DENOISER,
+        optimize=OPTIMIZE,
+        device=resolve_device(),
+    )
+    log_info(f"Model loaded elapsed_ms={int((time.perf_counter() - started_at) * 1000)}")
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    load_model()
+    yield
+
+
+app = FastAPI(title="TomoriBot VoxCPM2 TTS Server", lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict[str, str | bool | int | float | None]:
+    sample_rate = None
+    if model is not None:
+        sample_rate = int(model.tts_model.sample_rate)
+    return {
+        "status": "ok" if model is not None else "loading",
+        "model": "voxcpm2",
+        "model_id": MODEL_ID,
+        "device": DEVICE,
+        "sample_rate": sample_rate,
+        "voice_cloning": True,
+        "voice_design": True,
+        "controllable_cloning": True,
+        "ultimate_cloning": True,
+        "upstream_streaming": True,
+        "tomoribot_streaming": False,
+    }
+
+
+@app.post("/synthesize")
+def synthesize(payload: SynthesizeRequest) -> Response:
+    if model is None:
+        raise HTTPException(status_code=503, detail="VoxCPM2 is still loading.")
+
+    text = payload.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text is required.")
+    if len(text) > MAX_TEXT_CHARS:
+        raise HTTPException(status_code=400, detail=f"text exceeds {MAX_TEXT_CHARS} characters.")
+
+    synthesis_text = controlled_text(text, payload.instruct)
+    ref_text = payload.ref_text.strip() if payload.ref_text else ""
+    has_ref_audio = bool(payload.ref_audio and payload.ref_audio.strip())
+
+    with tempfile.TemporaryDirectory(prefix="tomori-voxcpm2-") as temp_dir:
+        reference_path = decode_ref_audio(payload.ref_audio, temp_dir) if has_ref_audio else None
+
+        kwargs = {
+            "text": synthesis_text,
+            "cfg_value": CFG_VALUE,
+            "inference_timesteps": INFERENCE_TIMESTEPS,
+            "max_len": MAX_LEN,
+            "normalize": NORMALIZE,
+            "denoise": LOAD_DENOISER,
+            "retry_badcase": RETRY_BADCASE,
+            "retry_badcase_max_times": RETRY_BADCASE_MAX_TIMES,
+            "retry_badcase_ratio_threshold": RETRY_BADCASE_RATIO_THRESHOLD,
+            "seed": SEED,
+        }
+
+        mode = "voice-design" if payload.instruct and not has_ref_audio else "zero-shot"
+        if reference_path:
+            kwargs["reference_wav_path"] = reference_path
+            mode = "controllable-clone" if payload.instruct else "clone"
+            if ref_text:
+                kwargs["prompt_wav_path"] = reference_path
+                kwargs["prompt_text"] = ref_text
+                mode = "ultimate-controllable-clone" if payload.instruct else "ultimate-clone"
+
+        started_at = time.perf_counter()
+        with model_lock:
+            try:
+                wav = model.generate(**kwargs)
+            except Exception as exc:
+                log_info(f"Synthesis failed mode={mode}: {exc}")
+                raise HTTPException(status_code=500, detail=f"VoxCPM2 synthesis failed: {exc}") from exc
+
+        buffer = io.BytesIO()
+        sf.write(buffer, wav, int(model.tts_model.sample_rate), format="WAV")
+        audio = buffer.getvalue()
+        log_info(
+            f"/synthesize completed mode={mode} text_chars={len(text)} language={payload.language or 'auto'} "
+            f"elapsed_ms={int((time.perf_counter() - started_at) * 1000)}"
+        )
+        return Response(content=audio, media_type="audio/wav")
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT)

--- a/servers/tts/voxcpm2/server.py
+++ b/servers/tts/voxcpm2/server.py
@@ -135,6 +135,7 @@ def load_model() -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+    validate_bind_policy()
     load_model()
     yield
 
@@ -230,5 +231,4 @@ def synthesize(
 
 
 if __name__ == "__main__":
-    validate_bind_policy()
     uvicorn.run(app, host=HOST, port=PORT)

--- a/servers/tts/voxcpm2/test_server.py
+++ b/servers/tts/voxcpm2/test_server.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import base64
+import io
+import unittest
+import wave
+
+import numpy as np
+
+import server
+
+
+def reference_wav() -> str:
+  buffer = io.BytesIO()
+  with wave.open(buffer, "wb") as output:
+    output.setnchannels(1)
+    output.setsampwidth(2)
+    output.setframerate(16000)
+    output.writeframes(b"\x00\x00" * 1600)
+  return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+class FakeTtsModel:
+  sample_rate = 16000
+
+
+class FakeModel:
+  def __init__(self) -> None:
+    self.tts_model = FakeTtsModel()
+    self.calls: list[dict[str, object]] = []
+
+  def generate(self, **kwargs: object) -> np.ndarray:
+    self.calls.append(kwargs)
+    return np.zeros(1600, dtype=np.float32)
+
+
+class VoxCpmContractTests(unittest.TestCase):
+  def setUp(self) -> None:
+    self.model = FakeModel()
+    server.model = self.model
+    server.API_KEY = ""
+    server.MAX_REF_AUDIO_BYTES = 10 * 1024 * 1024
+
+  def request(self, **kwargs: object) -> server.SynthesizeRequest:
+    return server.SynthesizeRequest(text="Hello there", **kwargs)
+
+  def test_voice_design_uses_instruct_without_reference(self) -> None:
+    response = server.synthesize(self.request(instruct="Warm and unhurried"))
+
+    self.assertEqual(response.media_type, "audio/wav")
+    self.assertEqual(len(self.model.calls), 1)
+    call = self.model.calls[0]
+    self.assertTrue(str(call["text"]).startswith("(Warm and unhurried)"))
+    self.assertNotIn("reference_wav_path", call)
+    self.assertNotIn("prompt_wav_path", call)
+    self.assertNotIn("prompt_text", call)
+
+  def test_reference_audio_uses_normal_cloning_without_transcript(self) -> None:
+    server.synthesize(self.request(ref_audio=reference_wav()))
+
+    call = self.model.calls[0]
+    self.assertIn("reference_wav_path", call)
+    self.assertNotIn("prompt_wav_path", call)
+    self.assertNotIn("prompt_text", call)
+
+  def test_reference_audio_and_transcript_use_ultimate_cloning(self) -> None:
+    server.synthesize(self.request(ref_audio=reference_wav(), ref_text="Reference words"))
+
+    call = self.model.calls[0]
+    self.assertIn("reference_wav_path", call)
+    self.assertEqual(call["prompt_wav_path"], call["reference_wav_path"])
+    self.assertEqual(call["prompt_text"], "Reference words")
+
+  def test_instruction_takes_precedence_over_transcript_for_cloning(self) -> None:
+    server.synthesize(
+      self.request(ref_audio=reference_wav(), ref_text="Reference words", instruct="Sound excited")
+    )
+
+    call = self.model.calls[0]
+    self.assertTrue(str(call["text"]).startswith("(Sound excited)"))
+    self.assertIn("reference_wav_path", call)
+    self.assertNotIn("prompt_wav_path", call)
+    self.assertNotIn("prompt_text", call)
+
+  def test_reference_audio_must_be_a_wav_container(self) -> None:
+    with self.assertRaises(server.HTTPException) as raised:
+      server.synthesize(self.request(ref_audio=base64.b64encode(b"not audio").decode("ascii")))
+
+    self.assertEqual(raised.exception.status_code, 400)
+
+  def test_reference_audio_size_is_checked_before_writing(self) -> None:
+    server.MAX_REF_AUDIO_BYTES = 4
+
+    with self.assertRaises(server.HTTPException) as raised:
+      server.synthesize(self.request(ref_audio=reference_wav()))
+
+    self.assertEqual(raised.exception.status_code, 413)
+
+  def test_configured_bearer_token_is_required_for_synthesis(self) -> None:
+    server.API_KEY = "secret"
+
+    with self.assertRaises(server.HTTPException) as raised:
+      server.synthesize(self.request(instruct="Warm"))
+    self.assertEqual(raised.exception.status_code, 401)
+
+    server.synthesize(self.request(instruct="Warm"), authorization="Bearer secret")
+
+  def test_remote_bind_requires_auth_or_explicit_opt_in(self) -> None:
+    previous_host = server.HOST
+    previous_key = server.API_KEY
+    previous_opt_in = server.ALLOW_REMOTE_BIND
+    try:
+      server.HOST = "0.0.0.0"
+      server.API_KEY = ""
+      server.ALLOW_REMOTE_BIND = False
+      with self.assertRaises(RuntimeError):
+        server.validate_bind_policy()
+
+      server.ALLOW_REMOTE_BIND = True
+      server.validate_bind_policy()
+    finally:
+      server.HOST = previous_host
+      server.API_KEY = previous_key
+      server.ALLOW_REMOTE_BIND = previous_opt_in
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/servers/tts/voxcpm2/test_server.py
+++ b/servers/tts/voxcpm2/test_server.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import unittest
 import wave
+from unittest.mock import patch
 
 import numpy as np
 
@@ -118,6 +120,28 @@ class VoxCpmContractTests(unittest.TestCase):
 
       server.ALLOW_REMOTE_BIND = True
       server.validate_bind_policy()
+    finally:
+      server.HOST = previous_host
+      server.API_KEY = previous_key
+      server.ALLOW_REMOTE_BIND = previous_opt_in
+
+  def test_remote_bind_policy_runs_before_model_load_in_lifespan(self) -> None:
+    previous_host = server.HOST
+    previous_key = server.API_KEY
+    previous_opt_in = server.ALLOW_REMOTE_BIND
+    try:
+      server.HOST = "0.0.0.0"
+      server.API_KEY = ""
+      server.ALLOW_REMOTE_BIND = False
+
+      async def start_application() -> None:
+        async with server.lifespan(server.app):
+          pass
+
+      with patch.object(server, "load_model") as load_model:
+        with self.assertRaises(RuntimeError):
+          asyncio.run(start_application())
+        load_model.assert_not_called()
     finally:
       server.HOST = previous_host
       server.API_KEY = previous_key

--- a/src/commands/generate/voice-message.ts
+++ b/src/commands/generate/voice-message.ts
@@ -58,6 +58,7 @@ import {
   validateVoiceSampleUpload,
 } from "@/utils/speech/voiceSampleAddOperation";
 import {
+  resolveVoiceSourceCapabilities,
   resolveVoiceSourceCandidates,
   selectDefaultVoiceSource,
   type VoiceSourceCandidate,
@@ -482,6 +483,7 @@ export async function execute(
   }
 
   const anyDesignShape = candidates.some((candidate) => candidate.shape === "design");
+  const cloneInstructionsAvailable = resolveVoiceSourceCapabilities(effectiveEndpoint).cloneInstructionsAvailable;
   const expressiveness = resolveExpressivenessBackend({
     endpoint: effectiveEndpoint,
     usesElevenLabs,
@@ -498,6 +500,7 @@ export async function execute(
       // only candidates are clone-shaped, a Delivery Direction field would render and then be
       // dropped by the dispatcher.
       designShapeAvailable: anyDesignShape,
+      cloneInstructionsAvailable,
       uploadShapeSelected: defaultSource?.id === "upload",
       expressiveness,
       chatterboxDefaults: {

--- a/src/providers/custom/styles/ttsCloningAdapter.ts
+++ b/src/providers/custom/styles/ttsCloningAdapter.ts
@@ -50,6 +50,8 @@ export interface TtsCloneRequest {
   script: string;
   /** Empty string for local endpoints that don't require auth. */
   apiKey: string;
+  /** Optional per-message delivery direction for clone engines that advertise instruction support. */
+  voiceInstructions?: string;
   chatterbox?: {
     turboEnabled: boolean;
     cfgWeight: number;
@@ -134,6 +136,8 @@ export interface TtsCloneBufferRequest {
   script: string;
   /** Empty string for local endpoints that don't require auth. */
   apiKey: string;
+  /** Optional per-message delivery direction for clone engines that advertise instruction support. */
+  voiceInstructions?: string;
   chatterbox?: {
     turboEnabled: boolean;
     cfgWeight: number;
@@ -152,7 +156,7 @@ export interface TtsCloneBufferRequest {
  * 3. Returns the raw audio buffer and content-type.
  */
 export async function synthesizeSpeechViaTtsCloneBuffer(request: TtsCloneBufferRequest): Promise<TtsCloneResult> {
-  const { endpoint, refAudio, refText, script, apiKey, chatterbox } = request;
+  const { endpoint, refAudio, refText, script, apiKey, voiceInstructions, chatterbox } = request;
 
   const scriptMarkup = (endpoint.extra_config.script_markup as string | undefined) ?? "plain";
   const supportsInstruct = Boolean(endpoint.extra_config.supports_instruct);
@@ -201,7 +205,7 @@ export async function synthesizeSpeechViaTtsCloneBuffer(request: TtsCloneBufferR
   }
 
   if (supportsInstruct) {
-    body.instruct = null;
+    body.instruct = voiceInstructions?.trim() || null;
   }
 
   const endpointUrl = endpoint.endpoint_url.replace(/\/+$/, "");
@@ -282,7 +286,7 @@ export async function synthesizeSpeechViaTtsCloneBuffer(request: TtsCloneBufferR
  * 5. Returns the raw audio buffer and content-type.
  */
 export async function synthesizeSpeechViaTtsClone(request: TtsCloneRequest): Promise<TtsCloneResult> {
-  const { endpoint, voiceSampleId, script, apiKey, chatterbox } = request;
+  const { endpoint, voiceSampleId, script, apiKey, voiceInstructions, chatterbox } = request;
 
   const voiceSample = await loadVoiceSampleById(voiceSampleId);
 
@@ -313,6 +317,7 @@ export async function synthesizeSpeechViaTtsClone(request: TtsCloneRequest): Pro
     refText: sample.ref_text ?? null,
     script,
     apiKey,
+    ...(voiceInstructions ? { voiceInstructions } : {}),
     ...(chatterbox ? { chatterbox } : {}),
   });
 }

--- a/src/tools/functionCalls/generateVoiceMessageTool.ts
+++ b/src/tools/functionCalls/generateVoiceMessageTool.ts
@@ -85,8 +85,13 @@ export const VOICE_TOOL_VARIANTS = {
 
 export type VoiceScriptMarkup = keyof typeof VOICE_TOOL_VARIANTS;
 
-export function buildVoiceMessageToolVariant(tool: Tool, scriptMarkup: VoiceScriptMarkup): Tool {
+export function buildVoiceMessageToolVariant(
+  tool: Tool,
+  scriptMarkup: VoiceScriptMarkup,
+  options: { voiceInstructionsAvailable?: boolean } = {},
+): Tool {
   const variant = VOICE_TOOL_VARIANTS[scriptMarkup] ?? VOICE_TOOL_VARIANTS["bracket-tags"];
+  const voiceInstructionsAvailable = options.voiceInstructionsAvailable ?? scriptMarkup === "voice-design";
   const parameters: ToolParameterSchema = {
     ...tool.parameters,
     properties: {
@@ -95,7 +100,7 @@ export function buildVoiceMessageToolVariant(tool: Tool, scriptMarkup: VoiceScri
         ...tool.parameters.properties.script,
         description: variant.scriptDescription,
       },
-      ...(scriptMarkup === "voice-design"
+      ...(voiceInstructionsAvailable
         ? {
             voice_instructions: {
               type: "string" as const,
@@ -143,13 +148,18 @@ export class GenerateVoiceMessageTool extends BaseTool {
       context.state.activePersonaVoiceDesignPrompt,
       context.state.activePersonaVoiceName,
     );
+    const cloneInstructionsAvailable = resolveVoiceSourceCapabilities(
+      activeSpeechEndpoint?.endpoint,
+    ).cloneInstructionsAvailable;
     const variant = voiceDesign
       ? "voice-design"
       : scriptMarkup in VOICE_TOOL_VARIANTS
         ? (scriptMarkup as VoiceScriptMarkup)
         : "bracket-tags";
 
-    return buildVoiceMessageToolVariant(this, variant);
+    return buildVoiceMessageToolVariant(this, variant, {
+      voiceInstructionsAvailable: voiceDesign || cloneInstructionsAvailable,
+    });
   }
 
   private resolveThreadId(context: ToolContext): string | undefined {

--- a/src/utils/speech/voiceMessageModal.ts
+++ b/src/utils/speech/voiceMessageModal.ts
@@ -62,6 +62,8 @@ export interface VoiceMessageModalInput {
   scriptMarkup: string | undefined;
   /** Render the Delivery Direction field: some design-shaped source is available. */
   designShapeAvailable: boolean;
+  /** Render Delivery Direction for clone-shaped requests that support `instruct`. */
+  cloneInstructionsAvailable: boolean;
   /** Render the Reference Transcript field: an uploaded clip will be cloned. */
   uploadShapeSelected: boolean;
   /** Render the delivery-knob radio, or null when the backend has no such knob. */
@@ -194,7 +196,7 @@ export function buildVoiceMessageModalComponents(input: VoiceMessageModalInput):
   const sourceField = buildVoiceSourceField(locale, input.candidates);
   if (sourceField) components.push(sourceField);
 
-  if (input.designShapeAvailable) {
+  if (input.designShapeAvailable || input.cloneInstructionsAvailable) {
     components.push({
       customId: VOICE_MESSAGE_DIRECTION_INPUT_ID,
       labelKey: "commands.generate.voice-message.modal.direction_label",

--- a/src/utils/speech/voiceMessageSynthesis.ts
+++ b/src/utils/speech/voiceMessageSynthesis.ts
@@ -60,7 +60,7 @@ export interface VoiceMessageSynthesisRequest {
   elevenLabsApiKey: string;
   source: ResolvedVoiceSource;
   script: string;
-  /** Per-message delivery direction, design-shaped sources only. */
+  /** Per-message delivery direction for design-shaped or instruction-capable clone sources. */
   voiceInstructions?: string;
   /** Chatterbox delivery overrides for this invocation, clone sources only. */
   chatterbox?: {
@@ -155,6 +155,7 @@ export async function synthesizeVoiceMessage(
             voiceSampleId: source.voiceSampleId,
             script,
             apiKey: endpointApiKey,
+            ...(request.voiceInstructions ? { voiceInstructions: request.voiceInstructions } : {}),
             ...(chatterbox ? { chatterbox } : {}),
           })
         : await synthesizeSpeechViaTtsCloneBuffer({
@@ -163,6 +164,7 @@ export async function synthesizeVoiceMessage(
             refText: source.refText,
             script,
             apiKey: endpointApiKey,
+            ...(request.voiceInstructions ? { voiceInstructions: request.voiceInstructions } : {}),
             ...(chatterbox ? { chatterbox } : {}),
           });
 

--- a/src/utils/speech/voiceSourceCapabilities.ts
+++ b/src/utils/speech/voiceSourceCapabilities.ts
@@ -14,6 +14,8 @@ export interface VoiceSourceCapabilities {
   acceptsCloneShape: boolean;
   /** Endpoint accepts design-shaped bodies (`instruct`). */
   acceptsDesignShape: boolean;
+  /** Clone-shaped bodies may carry a one-off delivery instruction in `instruct`. */
+  cloneInstructionsAvailable: boolean;
 }
 
 function getVoiceMode(endpoint: CustomEndpointRow | null | undefined): "clone" | "voice-design" | "auto" {
@@ -32,12 +34,15 @@ export function resolveVoiceSourceCapabilities(
   endpoint: CustomEndpointRow | null | undefined,
 ): VoiceSourceCapabilities {
   if (endpoint?.api_style !== "tts-clone") {
-    return { acceptsCloneShape: false, acceptsDesignShape: false };
+    return { acceptsCloneShape: false, acceptsDesignShape: false, cloneInstructionsAvailable: false };
   }
 
   const mode = getVoiceMode(endpoint);
+  const acceptsCloneShape = mode === "clone" || mode === "auto";
+  const acceptsDesignShape = mode === "voice-design" || mode === "auto";
   return {
-    acceptsCloneShape: mode === "clone" || mode === "auto",
-    acceptsDesignShape: mode === "voice-design" || mode === "auto",
+    acceptsCloneShape,
+    acceptsDesignShape,
+    cloneInstructionsAvailable: acceptsCloneShape && endpoint.extra_config.supports_instruct === true,
   };
 }

--- a/tests/unit/misc/launchReadiness.test.ts
+++ b/tests/unit/misc/launchReadiness.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_PYTHON_HEALTH_TIMEOUT_MS, resolvePositiveTimeoutMs } from "../../../scripts/lib/launchReadiness";
+
+describe("launch readiness timeout", () => {
+  it("uses the default for missing or invalid values", () => {
+    for (const value of [undefined, "", "nope", "0", "-1", "Infinity"]) {
+      expect(resolvePositiveTimeoutMs(value, DEFAULT_PYTHON_HEALTH_TIMEOUT_MS)).toBe(DEFAULT_PYTHON_HEALTH_TIMEOUT_MS);
+    }
+  });
+
+  it("keeps finite positive overrides usable as whole milliseconds", () => {
+    expect(resolvePositiveTimeoutMs("1234", DEFAULT_PYTHON_HEALTH_TIMEOUT_MS)).toBe(1234);
+    expect(resolvePositiveTimeoutMs("1.2", DEFAULT_PYTHON_HEALTH_TIMEOUT_MS)).toBe(2);
+  });
+});

--- a/tests/unit/speech/voiceMessageModal.test.ts
+++ b/tests/unit/speech/voiceMessageModal.test.ts
@@ -33,6 +33,7 @@ function makeEndpoint(options: {
   modelName?: string;
   endpointUrl?: string;
   scriptMarkup?: string;
+  supportsInstruct?: boolean;
 }): CustomEndpointRow {
   return {
     label: options.label ?? "Speech",
@@ -42,6 +43,7 @@ function makeEndpoint(options: {
     extra_config: {
       ...(options.voiceMode ? { voice_mode: options.voiceMode } : {}),
       ...(options.scriptMarkup ? { script_markup: options.scriptMarkup } : {}),
+      ...(options.supportsInstruct !== undefined ? { supports_instruct: options.supportsInstruct } : {}),
     },
   } as unknown as CustomEndpointRow;
 }
@@ -57,6 +59,12 @@ const NON_CHATTERBOX_CLONE = makeEndpoint({
   label: "Qwen3-TTS",
   modelName: "qwen3-tts",
   endpointUrl: "https://qwen.example.test",
+});
+
+const INSTRUCTION_CLONE = makeEndpoint({
+  voiceMode: "clone",
+  label: "VoxCPM2",
+  supportsInstruct: true,
 });
 
 const VOICE_DESIGN_ONLY = makeEndpoint({ voiceMode: "voice-design", label: "Qwen3 VoiceDesign" });
@@ -91,6 +99,7 @@ function buildInput(options: {
     scriptMarkup: options.endpoint.extra_config.script_markup as string | undefined,
     designShapeAvailable:
       candidates.some((candidate) => candidate.shape === "design") || capabilities.acceptsDesignShape,
+    cloneInstructionsAvailable: capabilities.cloneInstructionsAvailable,
     uploadShapeSelected: defaultSource?.id === "upload",
     expressiveness: options.expressiveness,
     chatterboxDefaults: { cfgWeight: 0.5, exaggeration: 0.5 },
@@ -217,6 +226,16 @@ describe("buildVoiceMessageModalComponents", () => {
 
     expect(componentIds(input)).not.toContain(VOICE_MESSAGE_DIRECTION_INPUT_ID);
   });
+
+  it("renders delivery direction for an instruction-capable clone endpoint", () => {
+    const input = buildInput({
+      endpoint: INSTRUCTION_CLONE,
+      persona: { speech_voice_sample_id: 12 },
+      expressiveness: null,
+    });
+
+    expect(componentIds(input)).toContain(VOICE_MESSAGE_DIRECTION_INPUT_ID);
+  });
 });
 
 describe("buildVoiceMessageModalComponents radio options", () => {
@@ -273,6 +292,7 @@ describe("buildVoiceMessageModalComponents radio options", () => {
       candidates: [{ id: "elevenlabs", shape: "elevenlabs" }],
       scriptMarkup: undefined,
       designShapeAvailable: false,
+      cloneInstructionsAvailable: false,
       uploadShapeSelected: false,
       expressiveness: "elevenlabs",
       chatterboxDefaults: { cfgWeight: 0.5, exaggeration: 0.5 },

--- a/tests/unit/speech/voiceMessageSynthesis.test.ts
+++ b/tests/unit/speech/voiceMessageSynthesis.test.ts
@@ -89,6 +89,7 @@ function makeEndpoint(options: {
   apiStyle?: CustomEndpointRow["api_style"];
   voiceMode?: VoiceMode;
   scriptMarkup?: string;
+  supportsInstruct?: boolean;
 }): CustomEndpointRow {
   return {
     label: "Speech",
@@ -97,6 +98,7 @@ function makeEndpoint(options: {
     extra_config: {
       ...(options.voiceMode ? { voice_mode: options.voiceMode } : {}),
       ...(options.scriptMarkup ? { script_markup: options.scriptMarkup } : {}),
+      ...(options.supportsInstruct !== undefined ? { supports_instruct: options.supportsInstruct } : {}),
     },
   } as unknown as CustomEndpointRow;
 }
@@ -218,6 +220,26 @@ describe("synthesizeVoiceMessage clone sources", () => {
     expect(cloneRequests[0]).toMatchObject({ refText: "reference words" });
   });
 
+  it("forwards clone delivery direction to the clone adapter", async () => {
+    const { calls } = await dispatch(makeEndpoint({ voiceMode: "clone", supportsInstruct: true }), CLONE_SOURCE, {
+      voiceInstructions: "sound calm and close",
+    });
+
+    expect(calls).toEqual(["clone"]);
+    expect(cloneRequests[0]).toMatchObject({ voiceInstructions: "sound calm and close" });
+  });
+
+  it("forwards clone delivery direction for ad-hoc uploads", async () => {
+    const { calls } = await dispatch(
+      makeEndpoint({ voiceMode: "clone", supportsInstruct: true }),
+      CLONE_BUFFER_SOURCE,
+      { voiceInstructions: "speak softly" },
+    );
+
+    expect(calls).toEqual(["clone-buffer"]);
+    expect(cloneRequests[0]).toMatchObject({ voiceInstructions: "speak softly" });
+  });
+
   it("refuses a clone source on a voice-design-only endpoint without reaching a backend", async () => {
     // Still `api_style === "tts-clone"`, so an api_style-only guard would post a clone-shaped body
     // to an instruct-only server.
@@ -289,6 +311,7 @@ describe("design-shape capability", () => {
       expect(resolveVoiceSourceCapabilities(endpoint)).toEqual({
         acceptsCloneShape: false,
         acceptsDesignShape: false,
+        cloneInstructionsAvailable: false,
       });
     }
   });

--- a/tests/unit/speech/voiceSourceResolution.test.ts
+++ b/tests/unit/speech/voiceSourceResolution.test.ts
@@ -18,12 +18,16 @@ import {
 
 type VoiceMode = "clone" | "voice-design" | "auto";
 
-function makeEndpoint(apiStyle: CustomEndpointRow["api_style"], voiceMode?: VoiceMode): CustomEndpointRow {
+function makeEndpoint(
+  apiStyle: CustomEndpointRow["api_style"],
+  voiceMode?: VoiceMode,
+  supportsInstruct = false,
+): CustomEndpointRow {
   return {
     label: "Test Speech",
     api_style: apiStyle,
     endpoint_url: "https://speech.example.test",
-    extra_config: voiceMode ? { voice_mode: voiceMode } : {},
+    extra_config: { ...(voiceMode ? { voice_mode: voiceMode } : {}), supports_instruct: supportsInstruct },
   } as unknown as CustomEndpointRow;
 }
 
@@ -46,27 +50,43 @@ function ids(candidates: readonly VoiceSourceCandidate[]): string[] {
 
 describe("resolveVoiceSourceCapabilities", () => {
   it("treats a missing endpoint as accepting neither shape", () => {
-    expect(resolveVoiceSourceCapabilities(null)).toEqual({ acceptsCloneShape: false, acceptsDesignShape: false });
+    expect(resolveVoiceSourceCapabilities(null)).toEqual({
+      acceptsCloneShape: false,
+      acceptsDesignShape: false,
+      cloneInstructionsAvailable: false,
+    });
   });
 
   it("defaults an unset voice_mode to clone", () => {
     expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone"))).toEqual({
       acceptsCloneShape: true,
       acceptsDesignShape: false,
+      cloneInstructionsAvailable: false,
     });
   });
 
   it("gives auto both shapes", () => {
-    expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone", "auto"))).toEqual({
+    expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone", "auto", true))).toEqual({
       acceptsCloneShape: true,
       acceptsDesignShape: true,
+      cloneInstructionsAvailable: true,
     });
+  });
+
+  it("only enables clone delivery direction when the endpoint opts into it", () => {
+    expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone", "clone", true)).cloneInstructionsAvailable).toBe(
+      true,
+    );
+    expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone", "clone", false)).cloneInstructionsAvailable).toBe(
+      false,
+    );
   });
 
   it("gives voice-design endpoints only the design shape", () => {
     expect(resolveVoiceSourceCapabilities(makeEndpoint("tts-clone", "voice-design"))).toEqual({
       acceptsCloneShape: false,
       acceptsDesignShape: true,
+      cloneInstructionsAvailable: false,
     });
   });
 
@@ -74,6 +94,7 @@ describe("resolveVoiceSourceCapabilities", () => {
     expect(resolveVoiceSourceCapabilities(makeEndpoint("elevenlabs"))).toEqual({
       acceptsCloneShape: false,
       acceptsDesignShape: false,
+      cloneInstructionsAvailable: false,
     });
   });
 });

--- a/tests/unit/tools/toolAssembly.test.ts
+++ b/tests/unit/tools/toolAssembly.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { assembleToolsForContext } from "@/tools/assembly";
 import { buildGenerateImageToolVariant, GenerateImageTool } from "@/tools/functionCalls/generateImageTool";
 import type { ImageToolCapabilities } from "@/tools/functionCalls/generateImageToolCapabilities";
@@ -6,6 +6,25 @@ import { buildVoiceMessageToolVariant, GenerateVoiceMessageTool } from "@/tools/
 import { buildWebSearchToolVariant, WebSearchTool } from "@/tools/webSearch/webSearchTool";
 import type { SearchCategory } from "@/tools/webSearch/types";
 import type { Tool, ToolAssemblyContext, ToolAssemblyState, ToolResult } from "@/types/tool/interfaces";
+import type { CustomEndpointRow } from "@/types/db/schema";
+import * as realSpeechEndpointResolver from "@/utils/provider/speechEndpointResolver";
+import { createScopedModuleMocker } from "../../helpers/mockSurface";
+
+const scopedMock = createScopedModuleMocker(mock, {
+  "@/utils/provider/speechEndpointResolver": realSpeechEndpointResolver,
+});
+
+scopedMock.module("@/utils/provider/speechEndpointResolver", () => ({
+  ...realSpeechEndpointResolver,
+  resolveActiveSpeechEndpoint: async () => ({
+    endpoint: {
+      api_style: "tts-clone",
+      endpoint_url: "http://127.0.0.1:8016",
+      extra_config: { voice_mode: "clone", script_markup: "plain", supports_instruct: true },
+    } as unknown as CustomEndpointRow,
+    apiKey: "",
+  }),
+}));
 
 function createAssemblyState(overrides: Partial<ToolAssemblyState> = {}): ToolAssemblyState {
   return {
@@ -221,5 +240,22 @@ describe("tool schema assembly", () => {
 
     expect(getPropertyNames(tool)).toEqual(["script", "title", "voice_instructions"]);
     expect(tool.description).toContain("voice design prompt");
+  });
+
+  it("assembles generate_voice_message with clone instructions when the endpoint advertises them", () => {
+    const tool = buildVoiceMessageToolVariant(new GenerateVoiceMessageTool(), "plain", {
+      voiceInstructionsAvailable: true,
+    });
+
+    expect(getPropertyNames(tool)).toEqual(["script", "title", "voice_instructions"]);
+    expect(tool.parameters.properties.voice_instructions?.description).toContain("one-off delivery");
+  });
+
+  it("assembles clone instructions from the active endpoint capability", async () => {
+    const assembled = await assembleToolsForContext([new GenerateVoiceMessageTool()], createAssemblyContext());
+    const tool = assembled[0];
+
+    expect(tool).toBeDefined();
+    expect(getPropertyNames(tool as Tool)).toContain("voice_instructions");
   });
 });


### PR DESCRIPTION
## Summary

Adds VoxCPM2 as a new self-hosted local TTS sidecar for TomoriBot.

- Adds `servers/tts/voxcpm2/`, a thin FastAPI compatibility wrapper around the official `voxcpm` Python package while preserving TomoriBot's existing `POST /synthesize` contract.
- Defaults to the official `openbmb/VoxCPM2` 2B BF16 model with the stable `voxcpm==2.0.3` runtime.
- Supports normal reference-audio voice cloning through `ref_audio`.
- Uses the stored `ref_text` together with the same reference clip for VoxCPM2 Ultimate Cloning when a transcript is available.
- Maps TomoriBot's `instruct` field to VoxCPM2's native parenthesized natural-language Voice Design/control syntax, supporting both text-only Voice Design and controllable reference-audio cloning without introducing a new TomoriBot request format.
- Uses `Plain` Script Markup because expressive/style control is carried separately through `instruct` rather than bracket tags or emoji markup.
- Adds Linux/WSL Bash and native Windows PowerShell setup scripts, with optional model prefetching.
- Adds `bun run launch --voxcpm2` support.
- Adds a dedicated English VoxCPM2 guide and updates the local-endpoint, TTS, launcher, and root README overviews for the command-modernization `/providers`, `/config`, and `/generate voice-message` flow.

## Model and hardware

The default remains the normal official VoxCPM2 checkpoint rather than a community quantization. OpenBMB reports roughly 8 GB VRAM for the standard VoxCPM2 runtime, so it comfortably fits the requested ~16 GB consumer NVIDIA GPU target without taking a quality/compatibility tradeoff.

The sidecar defaults the optional upstream denoiser off to avoid extra memory/runtime overhead. Advanced users can enable it with an environment variable.

VoxCPM2 itself supports streaming generation, but TomoriBot's current `/synthesize` contract returns one WAV response, so this reference wrapper buffers the generated utterance and returns `audio/wav`.

## Installation platforms

- Linux / WSL: `servers/tts/voxcpm2/install-voxcpm2.sh`
- Windows PowerShell: `servers/tts/voxcpm2/install-voxcpm2.ps1`
- Python 3.10-3.12
- CUDA-enabled PyTorch recommended for NVIDIA GPU inference; CPU fallback remains available upstream

The official `voxcpm` package is OS-independent and supports explicit `cuda`, `cuda:N`, `cpu`, and `mps` device selection, so WSL is not required for the standard Windows setup.

## Licensing

VoxCPM2 code and model weights are Apache-2.0. TomoriBot does not redistribute the weights; self-hosters download the official `openbmb/VoxCPM2` checkpoint through Hugging Face.

## Verification

- Reviewed the branch diff against `refactor/command-modernization`: exactly 10 intended files changed, with no unrelated files.
- Branch is based directly on the current `refactor/command-modernization` head and is 0 commits behind at PR creation time.
- `python -m py_compile servers/tts/voxcpm2/server.py` passes.
- `bash -n servers/tts/voxcpm2/install-voxcpm2.sh` passes.
- Cross-checked the wrapper arguments against the released `voxcpm==2.0.3` API rather than relying on unreleased upstream `main` additions.
- Model weights were intentionally not downloaded as part of these lightweight verification checks.
- Bun and PowerShell are not installed in the execution environment used for these checks, so their native parsers were not available locally.

## Base branch

This PR intentionally targets `refactor/command-modernization`, not `main`, so the documentation and integration use the current `/providers`, `/config`, and `/generate voice-message` UX.